### PR TITLE
CASMINST-3082: Verify cfs-state-reporter on storage NCNs, now that spire has been enabled on them

### DIFF
--- a/cmsdev/internal/test/cfs/cfs.go
+++ b/cmsdev/internal/test/cfs/cfs.go
@@ -114,7 +114,7 @@ func IsCFSRunning() (passed bool) {
 		passed = false
 	}
 	// This function is defined in cfs_state_reporter.go
-	if !verifyCfsStateReporterOnMasterAndWorkers() {
+	if !verifyCfsStateReporterOnNcns() {
 		passed = false
 	}
 	if !passed {

--- a/cmsdev/internal/test/cfs/cfs_state_reporter.go
+++ b/cmsdev/internal/test/cfs/cfs_state_reporter.go
@@ -207,10 +207,10 @@ func checkCfsStateReporterOnRemoteHost(remoteHost string, config *ssh.ClientConf
 	return true
 }
 
-// Extract from /etc/hosts the list of all master and worker NCNs, except for the current host
-func getMastersAndWorkers() (ncns []string, err error) {
+// Extract from /etc/hosts the list of all NCNs, except for the current host
+func getNcns() (ncns []string, err error) {
 	result, err := common.RunPath("/bin/bash", "-c",
-		"grep -o -E \"ncn-[mw][0-9][0-9][0-9]([[:space:]]|$)\" /etc/hosts | grep -Ev \"^$HOSTNAME$\"")
+		"grep -o -E \"ncn-[msw][0-9][0-9][0-9]([[:space:]]|$)\" /etc/hosts | grep -Ev \"^$HOSTNAME$\"")
 	if err != nil {
 		err = fmt.Errorf("Error getting NCN hostnames from /etc/hosts: %v", err)
 		return
@@ -222,9 +222,9 @@ func getMastersAndWorkers() (ncns []string, err error) {
 	return
 }
 
-// We run our systemctl command on the local host and on all other master and worker nodes, validating
+// We run our systemctl command on the local host and on all other NCNs, validating
 // that our expected success string shows up in the output.
-func verifyCfsStateReporterOnMasterAndWorkers() (ok bool) {
+func verifyCfsStateReporterOnNcns() (ok bool) {
 	// Let's be optimistic! ok starts out as true
 	ok = true
 
@@ -244,17 +244,17 @@ func verifyCfsStateReporterOnMasterAndWorkers() (ok bool) {
 		}
 	}
 
-	common.Infof("Checking status of cfs-state-reporter on other master and worker NCNs")
+	common.Infof("Checking status of cfs-state-reporter on other NCNs")
 
-	common.Debugf("Getting list of other master and worker NCNs from /etc/hosts")
-	ncnList, err := getMastersAndWorkers()
+	common.Debugf("Getting list of other NCNs from /etc/hosts")
+	ncnList, err := getNcns()
 	if err != nil {
 		common.Error(err)
 		// Nothing more to do if we cannot get the list
 		ok = false
 		return
 	} else if len(ncnList) == 0 {
-		common.Errorf("No other master or worker NCNs found in /etc/hosts -- this should never be the case")
+		common.Errorf("No other NCNs found in /etc/hosts -- this should never be the case")
 		ok = false
 		return
 	}
@@ -263,7 +263,7 @@ func verifyCfsStateReporterOnMasterAndWorkers() (ok bool) {
 	config, err := getSSHConfig()
 	if err != nil {
 		common.Warnf("Unable to generate ssh configuration: %v", err)
-		common.Warnf("Unable to verify cfs-state-reporter status on other master and worker NCNs")
+		common.Warnf("Unable to verify cfs-state-reporter status on other NCNs")
 		// Nothing more we can do without the ssh configuration
 		return
 	}


### PR DESCRIPTION
### Summary and Scope
Currently the cmsdev CFS test checks the exit status of cfs-state-reporter on NCN master/worker nodes, to make sure it looks okay. It does not do this on storage NCNs because spire did not work on them, and thus cfs-state-reporter did not work. In csm-1.1 they have enabled spire on storage NCNs, so this PR just has the test run on storage NCNs as well. There is no change to the test itself, beyond:
* adding the storage NCNs to the list of test targets
* changing some messages (so they refer to all NCNs instead of just masters and workers)

Some code comments and functions also changed names, to reflect the new scope of the test.

Essentially, though, the test is identical, other than running on more nodes.

### Issues and Related PRs
* CASMPET-3997 enabled spire on storage NCNs in csm-1.1

### Testing
The test itself has been run during many installs, just not on storage nodes. Currently we have no systems installed with csm-1.1 alpha 16 or later, thus we have no systems where spire is enabled on storage nodes, so I cannot test that aspect of this PR. However, I did run the new test on a system just to verify that no regressions were introduced.

### Risks and Mitigations
Low risk. This PR changes no core logic the test.