### PR TITLE
CASMCMS-7228: Add RPM signing key test to cmsdev

### DIFF
--- a/cmsdev/internal/test/ims/ims.go
+++ b/cmsdev/internal/test/ims/ims.go
@@ -29,14 +29,15 @@ package ims
  */
 
 import (
-	coreV1 "k8s.io/api/core/v1"
 	"os"
 	"regexp"
+	"strings"
+
+	coreV1 "k8s.io/api/core/v1"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/cms"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
-	"strings"
 )
 
 func IsIMSRunning() (passed bool) {
@@ -278,6 +279,10 @@ func IsIMSRunning() (passed bool) {
 	if !passed && !artifactsCollected {
 		common.ArtifactsPodsPvcs(podNames, pvcNames)
 		artifactsCollected = true
+	}
+
+	if !signingkeysTest() {
+		passed = false
 	}
 
 	return

--- a/cmsdev/internal/test/ims/signingkeys.go
+++ b/cmsdev/internal/test/ims/signingkeys.go
@@ -1,0 +1,189 @@
+package ims
+
+/*
+ * signingkeys.go
+ *
+ * IMS signing keys test file
+ *
+ * Copyright 2021 Hewlett Packard Enterprise Development LP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * (MIT License)
+ */
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
+)
+
+// Run the command kubectl -n services get cm cray-configmap-ims-v2-image-create-kiwi-ng -o go-template='{{index .data "image_job_create.yaml.template"}}'
+// Get the image with kiwi-ng in the image name and return
+func getOpensuseImage() (imagename string, err error) {
+	imagename = ""
+	var cmd *exec.Cmd
+	var cmdOut []byte
+	var kubectlPath string
+
+	kubectlPath, err = k8s.GetKubectlPath()
+	if err != nil {
+		common.Errorf("Error getting kubectl path")
+		return
+	}
+	// kubectl -n services get cm cray-configmap-ims-v2-image-create-kiwi-ng -o go-template='{{index .data "image_job_create.yaml.template"}}'
+	cmd = exec.Command(kubectlPath, "-n", common.NAMESPACE, "get", "cm", "cray-configmap-ims-v2-image-create-kiwi-ng", "-o", "go-template='{{index .data \"image_job_create.yaml.template\"}}'")
+	common.Infof("Running command: %s", cmd)
+	cmdOut, err = cmd.CombinedOutput()
+	common.Debugf("OUT: %s", cmdOut)
+	if err == nil && len(cmdOut) == 0 {
+		err = fmt.Errorf("Command succeeded but gave no output")
+		return
+	} else if err != nil {
+		common.Errorf("Error getting Open SuSE Image from cray-configmap-ims-v2-image-create-kiwi-ng")
+		return
+	}
+	// Structure to parse yaml from kubectl and find images
+	type ImageName struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					InitContainers []struct {
+						Image string `yaml:"image"`
+					} `yaml:"initContainers"`
+				} `yaml:"spec"`
+			} `yaml:"template"`
+		} `yaml:"spec"`
+	}
+	var in ImageName
+	err = yaml.Unmarshal(cmdOut, &in)
+	if err != nil {
+		common.Errorf("Error parsing command output as YAML")
+		return
+	}
+	common.Debugf("SPEC: %s", in)
+	common.Debugf("Find image with name containing kiwi-ng")
+	for _, cont := range in.Spec.Template.Spec.InitContainers {
+		common.Debugf("NAME: %s", cont.Image)
+		if strings.Contains(cont.Image, "kiwi-ng") {
+			imagename = cont.Image
+			return
+		}
+	}
+	err = fmt.Errorf("No image found with name containing kiwi-ng")
+	return
+}
+
+// Run the command podman run --entrypoint "" registry.local/imagename ls /signing-keys
+// return the signing keys found
+func getSigningkeys(imagename string) (keys []string, err error) {
+	var cmd *exec.Cmd
+	var cmdOut []byte
+	// Run the command podman run --entrypoint "" registry.local/imagename ls /signing-keys
+	cmd = exec.Command("podman", "run", "--entrypoint", "\"\"", "registry.local/"+imagename, "ls", "/signing-keys")
+	//cmd = exec.Command("docker", "run", "--entrypoint=", "--rm", "artifactory.algol60.net/"+imagename, "ls", "/signing-keys")
+	common.Infof("Running command: %s", cmd)
+	cmdOut, err = cmd.CombinedOutput()
+	common.Debugf("OUT: %s", cmdOut)
+	if err != nil {
+		common.Errorf("Error running podman ls /signing-keys command")
+		return
+	}
+	// Find signing keys by finding strings that end with .asc
+	re := regexp.MustCompile(".*.asc")
+	keys = re.FindAllString(string(cmdOut), -1)
+	if len(keys) == 0 {
+		err = fmt.Errorf("podman ls /signing-keys command returned no keys")
+		return
+	}
+	for _, key := range keys {
+		common.Debugf("Found Key: %s", key)
+	}
+	return
+}
+
+// Run the command podman run --entrypoint "" registry.local/imagename cat /scripts/entrypoint.sh
+// Verify that keys are present in the script
+func verifySigningkeys(imagename string, keys []string) (err error) {
+	var cmd *exec.Cmd
+	var cmdOut []byte
+	// Run the command podman run --entrypoint "" registry.local/imagename cat /scripts/entrypoint.sh
+	cmd = exec.Command("podman", "run", "--entrypoint", "\"\"", "registry.local/"+imagename, "cat", "/scripts/entrypoint.sh")
+	//cmd = exec.Command("docker", "run", "--entrypoint=", "--rm", "artifactory.algol60.net/"+imagename, "cat", "/scripts/entrypoint.sh")
+	common.Infof("Running command: %s", cmd)
+	cmdOut, err = cmd.CombinedOutput()
+	common.Debugf("OUT: %s", cmdOut)
+	if err == nil && len(cmdOut) == 0 {
+		err = fmt.Errorf("Command succeeded but gave no output")
+		return
+	} else if err != nil {
+		common.Errorf("Error running podman cat /scripts/entrypoint.sh command")
+		return
+	}
+	keysfound := 0
+	// Look for lines with --signing-key /signing-keys/key
+	for _, key := range keys {
+		re := regexp.MustCompile(".*--signing-key /signing-keys/" + key)
+		foundkey := re.FindAllString(string(cmdOut), -1)
+		if len(foundkey) > 0 {
+			common.Debugf("Found Key: %s %s", key, foundkey[0])
+			keysfound++
+		}
+	}
+	if keysfound == len(keys) {
+		common.Debugf("Expected %d keys, found %d keys", len(keys), keysfound)
+		return
+	}
+	err = fmt.Errorf("We expected to find %d signing keys, but actually found %d", len(keys), keysfound)
+	return
+}
+
+// Run the signingkeys test
+func signingkeysTest() bool {
+	common.Infof("Performing RPM signing keys test")
+
+	// Get opensuse image
+	imagename, err := getOpensuseImage()
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// Get signingkeys
+	keys, err := getSigningkeys(imagename)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// verify signingkeys
+	err = verifySigningkeys(imagename, keys)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	common.Infof("RPM signing keys test passed")
+	return true
+}


### PR DESCRIPTION
Implement a CMSDev test to verify that the HPE and SuSE signing keys are available within the IMS Kiwi-NG container.