### PR TITLE
CASMTRIAGE-2732 - Fix barebones image boot test script to get input target compute node.

### DIFF
--- a/csm-health-checks/barebones-boot/barebonesImageTest.py
+++ b/csm-health-checks/barebones-boot/barebonesImageTest.py
@@ -342,6 +342,11 @@ def find_compute_node():
     compute node, look for that first.  If the user has not specified a node or the one
     the user specified is not available just use the first one returned by hsm.
     """
+
+    # log if the user has specified a compute node
+    if not INPUT_COMPUTE_NODE == None:
+        logger.debug(f"User specified compute node: {INPUT_COMPUTE_NODE}")
+
     # query for compute nodes that are enabled
     # cray hsm state components list --role Compute --enabled true
     url = API_GW_SECURE + "smd/hsm/v1/State/Components"
@@ -434,6 +439,13 @@ def parse_command_line():
     parser = argparse.ArgumentParser()
     parser.add_argument('-x', "--xname", nargs='?', help='Compute node to use for boot test')
     args = parser.parse_args()
+
+    # get specified compute node if present
+    if not args.xname == None:
+        INPUT_COMPUTE_NODE = args.xname
+        logger.debug(f"Input args.xname={args.xname}")
+    else:
+        logger.debug("Input arg xname not specified.")
 
 def get_access_token(k8sClientApi):
     """


### PR DESCRIPTION
## Summary and Scope

The option for the user to supply a compute node to use for the image boot test was not working.  This change takes the input argument and makes it flow into the rest of the script so it will be used.

## Issues and Related PRs
* Resolves CASMTRIAGE-2732

## Testing
### Tested on:
  * Wasp

### Test description:
I loaded the modified script on wasp and disabled that portion of the script that actually initiates the boot, but kept the argument processing and finding a compute node to use for the test.  I verified that when a node is specified on the command line it now flows through to the function that looks for an available node.  I also tested scenarios where there is nothing passed in and where an incorrect node xname is used.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? N - this is a test script
- Was upgrade tested? If not, why? N - this is a test script installed via rpm.
- Was downgrade tested? If not, why? N - this is a test script installed via rpm.
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations
This is a low risk change - it just modifies handling an optional input argument to a test script.  It will not impact any running system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
