### PR TITLE
CASMCMS-7691: Fix testcase bugs in new IMS signing keys test

### DIFF
--- a/cmsdev/internal/lib/k8s/k8s.go
+++ b/cmsdev/internal/lib/k8s/k8s.go
@@ -354,6 +354,30 @@ func GetNodeNames(params ...string) ([]string, error) {
 	return names, err
 }
 
+// Given a namespace and name, returns the matching configmap
+func GetConfigMap(namespace, name string) (cm coreV1.ConfigMap, err error) {
+	common.Debugf("Retrieving Kubernetes ConfigMap in namespace %s with name %s", namespace, name)
+
+	clientset, err := GetClientset()
+	if err != nil {
+		return
+	}
+
+	cmlist, err := clientset.CoreV1().ConfigMaps(namespace).List(v1.ListOptions{})
+	if err != nil {
+		return
+	}
+
+	for _, cm = range cmlist.Items {
+		if cm.ObjectMeta.Name == name {
+			common.Debugf("Found Kubernetes ConfigMap in namespace %s with name %s", namespace, name)
+			return
+		}
+	}
+	err = fmt.Errorf("No Kubernetes ConfigMap found in namespace %s with name %s", namespace, name)
+	return
+}
+
 // Given a namespace and name, returns the matching service
 func GetService(namespace, name string) (service coreV1.Service, err error) {
 	clientset, err := GetClientset()

--- a/cmsdev/internal/test/ims/signingkeys.go
+++ b/cmsdev/internal/test/ims/signingkeys.go
@@ -103,8 +103,7 @@ func getSigningkeys(imagename string) (keys []string, err error) {
 	var cmd *exec.Cmd
 	var cmdOut []byte
 	// Run the command podman run --entrypoint "" registry.local/imagename ls /signing-keys
-	cmd = exec.Command("podman", "run", "--entrypoint", "\"\"", "registry.local/"+imagename, "ls", "/signing-keys")
-	//cmd = exec.Command("docker", "run", "--entrypoint=", "--rm", "artifactory.algol60.net/"+imagename, "ls", "/signing-keys")
+	cmd = exec.Command("podman", "run", "--entrypoint", "", "registry.local/"+imagename, "ls", "/signing-keys")
 	common.Infof("Running command: %s", cmd)
 	cmdOut, err = cmd.CombinedOutput()
 	common.Debugf("OUT: %s", cmdOut)
@@ -131,8 +130,7 @@ func verifySigningkeys(imagename string, keys []string) (err error) {
 	var cmd *exec.Cmd
 	var cmdOut []byte
 	// Run the command podman run --entrypoint "" registry.local/imagename cat /scripts/entrypoint.sh
-	cmd = exec.Command("podman", "run", "--entrypoint", "\"\"", "registry.local/"+imagename, "cat", "/scripts/entrypoint.sh")
-	//cmd = exec.Command("docker", "run", "--entrypoint=", "--rm", "artifactory.algol60.net/"+imagename, "cat", "/scripts/entrypoint.sh")
+	cmd = exec.Command("podman", "run", "--entrypoint", "", "registry.local/"+imagename, "cat", "/scripts/entrypoint.sh")
 	common.Infof("Running command: %s", cmd)
 	cmdOut, err = cmd.CombinedOutput()
 	common.Debugf("OUT: %s", cmdOut)

--- a/cmsdev/internal/test/ims/signingkeys.go
+++ b/cmsdev/internal/test/ims/signingkeys.go
@@ -39,31 +39,33 @@ import (
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
 )
 
-// Run the command kubectl -n services get cm cray-configmap-ims-v2-image-create-kiwi-ng -o go-template='{{index .data "image_job_create.yaml.template"}}'
-// Get the image with kiwi-ng in the image name and return
+const configMapName = "cray-configmap-ims-v2-image-create-kiwi-ng"
+const imageFieldName = "image_job_create.yaml.template"
+
+// Retrieve the cray-configmap-ims-v2-image-create-kiwi-ng configmap in kubernetes
+// Look at the data field for "image_job_create.yaml.template"
+// Parse that field to find the image which has kiwi-ng in its name, and return that name
 func getOpensuseImage() (imagename string, err error) {
 	imagename = ""
-	var cmd *exec.Cmd
-	var cmdOut []byte
-	var kubectlPath string
 
-	kubectlPath, err = k8s.GetKubectlPath()
+	// Get configmap
+	cm, err := k8s.GetConfigMap(common.NAMESPACE, configMapName)
 	if err != nil {
-		common.Errorf("Error getting kubectl path")
 		return
 	}
-	// kubectl -n services get cm cray-configmap-ims-v2-image-create-kiwi-ng -o go-template='{{index .data "image_job_create.yaml.template"}}'
-	cmd = exec.Command(kubectlPath, "-n", common.NAMESPACE, "get", "cm", "cray-configmap-ims-v2-image-create-kiwi-ng", "-o", "go-template='{{index .data \"image_job_create.yaml.template\"}}'")
-	common.Infof("Running command: %s", cmd)
-	cmdOut, err = cmd.CombinedOutput()
-	common.Debugf("OUT: %s", cmdOut)
-	if err == nil && len(cmdOut) == 0 {
-		err = fmt.Errorf("Command succeeded but gave no output")
-		return
-	} else if err != nil {
-		common.Errorf("Error getting Open SuSE Image from cray-configmap-ims-v2-image-create-kiwi-ng")
+
+	// Retrieve image_job_create.yaml.template data field
+	common.Debugf("Retrieve Data field '%s' from ConfigMap", imageFieldName)
+	imageDataField, keyFound := cm.Data[imageFieldName]
+	if !keyFound {
+		err = fmt.Errorf("No field named '%s' found in Kubernetes ConfigMap %s in namespace %s", imageFieldName, configMapName, common.NAMESPACE)
 		return
 	}
+
+	// Make sure we can convert the field to a byte slice
+	common.Debugf("Convert %s field to byte slice", imageFieldName)
+	imageFieldBytes := []byte(imageDataField)
+
 	// Structure to parse yaml from kubectl and find images
 	type ImageName struct {
 		Spec struct {
@@ -77,7 +79,7 @@ func getOpensuseImage() (imagename string, err error) {
 		} `yaml:"spec"`
 	}
 	var in ImageName
-	err = yaml.Unmarshal(cmdOut, &in)
+	err = yaml.Unmarshal(imageFieldBytes, &in)
 	if err != nil {
 		common.Errorf("Error parsing command output as YAML")
 		return

--- a/cray-cmstools-crayctldeploy.spec
+++ b/cray-cmstools-crayctldeploy.spec
@@ -40,6 +40,8 @@ Cray CMS tests and tools
 
 %build
 pushd cmsdev
+# Record the go version in the build output, just in case
+go version
 make build
 popd
 


### PR DESCRIPTION
## Summary and Scope

TLDR; This fixes two testcase bugs in the new IMS signing keys test. Without these fixes, this test always fails, which is bad since this test is part of the standard CSM health check procedure performed during installs.

In csm-1.2 a new subtest was added to the cmsdev tool to test IMS signing keys. When the test was added, no system was available with the new feature, so the test could not be successfully run before it was merged. As it turns out, the test had two bugs in it. This PR addresses those. Specifically:
* The test used the kubectl command to get information from a Kubernetes configmap. Something in the way it was doing that was causing issues with YAML parsing. I verified that the information in Kubernetes was correct, which led me to conclude that this was some golang subtlety that I was unable to detect. However, I also realized that we should not be using kubectl to get this information in the first place. Instead, we should be using the golang kubernetes API. I changed the test to use the API and the problem was resolved.
* The test was trying to run the podman command incorrectly. It wanted to pass an empty argument to the entrypoint parameter, but it was doing it shell script style (passing in two quotation marks). When calling the command from golang, it is sufficient just to pass an empty golang string for that argument. Once I made that change, the podman commands ran as they were intended to.

While originally investigating this issue I wanted to rule out that the golang version was not somehow causing a problem. I noticed that the Jenkins build output did not include the golang version being used, so I added a line in the RPM specfile to print the golang version at build time.

## Issues and Related PRs

This resolves CASMCMS-7691 (and whatever tickets have been opened that were duplicates of it).

## Testing

I tested the updated cmsdev tool on wasp, the only 1.2 system I had at hand. I verified that the test was failing without the fix, and passes with the fix.

## Risks and Mitigations

It's always possible that I inadvertently broke something else in trying to fix this, but I think it's unlikely. Given that my changes are confined to this subtest (and creating a new function that is called only by this subtest), it seems unlikely that any unexpected failures would extend beyond this subtest. And given that this subtest fails every time without these fixes, the worst case is that it still wouldn't work. But the changes I made are fairly simple in scope, so I think the risk of new problems being introduced is low.

It *is* possible that we may still see this test fail on some systems. I say this because we haven't been able to run it at all until I fixed these bugs. So it's possible the test has other bugs in it that we have not yet detected, which would only be exposed when it is run on different systems. Or it is possible that some systems will have actual issues with the IMS feature being tested, in which case the test failure would be desirable.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

