### PR TITLE
CASMCMS-8073: Use HSMv2 API instead of v1

### DIFF
--- a/csm-health-checks/barebones-boot/barebonesImageTest.py
+++ b/csm-health-checks/barebones-boot/barebonesImageTest.py
@@ -349,7 +349,7 @@ def find_compute_node():
 
     # query for compute nodes that are enabled
     # cray hsm state components list --role Compute --enabled true
-    url = API_GW_SECURE + "smd/hsm/v1/State/Components"
+    url = API_GW_SECURE + "smd/hsm/v2/State/Components"
     headers = {"Authorization": f"Bearer {API_GW_TOKEN}"}
     params = {"Role":"Compute", "Enabled":"True"}
     r = requests.get(url, headers = headers, params = params)


### PR DESCRIPTION
## Summary and Scope

Replace the sole remaining HSM v1 API call with v2. I confirmed that for this endpoint, with the parameters we are using, there is no change in behavior, so just swapping the endpoint is all that is needed.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
