### PR TITLE
CASMCMS-8069: Barebones boot test now fails if user requested compute node is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Barebones boot test now fails if user specifies a compute node that is not available.
 
 ## [1.4.0] - 2022-07-13
+
 ### Added
 - Enabled gitversion and gitflow
 

--- a/csm-health-checks/barebones-boot/barebonesImageTest.py
+++ b/csm-health-checks/barebones-boot/barebonesImageTest.py
@@ -339,8 +339,8 @@ def create_session_template(imsEtag, imsPath):
 def find_compute_node():
     """
     Find a compute node to use for the boot test.  If the user has specified a particular
-    compute node, look for that first.  If the user has not specified a node or the one
-    the user specified is not available just use the first one returned by hsm.
+    compute node, look for that one, and fail if it is not available.  If the user has not specified
+    a node, just use the first one returned by hsm.
     """
 
     # log if the user has specified a compute node
@@ -387,9 +387,10 @@ def find_compute_node():
     if matchNode != "":
         return matchNode
 
-    # report if user specified node was not found
+    # fail if user specified node was not found
     if not INPUT_COMPUTE_NODE is None:
-        logger.warning(f"User specified node {INPUT_COMPUTE_NODE} not found, defaulting to node {firstNode}")
+        logger.error(f"User specified node {INPUT_COMPUTE_NODE} not found in HSM list of enabled compute nodes")
+        raise BBException()
     return firstNode
 
 def start_bos_session(template_name, compute_node):


### PR DESCRIPTION
## Summary and Scope

In some cases a person running the barebones boot test has a specific node that is available to be rebooted. The current behavior of the test (to choose a different node if the requested node is unavailable) is not ideal, because it means that people in that situation are taking a risk by executing the test. Even if they are sure that their node is available, if there is an HSM problem or they make a typo, a different compute node would be rebooted.

This PR changes the behavior of the test so that if the user specifies a compute node, the test will fail if that node is not found.

As before, the test default behavior (if no node is specified) is to pick one itself, so that ability still exists. This just gives users a safe way to run the test without risking different compute nodes being rebooted.

## Testing

I tested the modified script on rocket and verified that all 3 paths work as expected:
1. User does not specify a node
2. User specifies a node that is available
3. User specifies a node that is not available

I did not run the full boot test when doing this testing -- I modified it so that the test exited once it got past the point of selecting the node (since after that there are no changes made by this PR).

## Risks and Mitigations

Low risk to include this. I think if we don't make this change, sooner or later we're going to have an unhappy customer.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
