### PR TITLE
Set RPM version and release fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Barebones boot test now fails if user specifies a compute node that is not available.
+- Modified RPM build process to use RPM release and version fields
 
 ## [1.4.0] - 2022-07-13
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -37,7 +37,7 @@ pipeline {
     }
 
     environment {
-        NAME = "cray-cmstools"
+        NAME = "cray-cmstools-crayctldeploy"
         DESCRIPTION = "Cray Management System - Tests"
         IS_STABLE = getBuildIsStable()
         CMSDEV_SPEC_FILE = "cray-cmstools-crayctldeploy.spec"

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,14 @@
 # If you wish to perform a local build, you will need to clone or copy the contents of the
 # cms-meta-tools repo to ./cms_meta_tools
 
-NAME ?= cray-cmstools
+NAME ?= cray-cmstools-crayctldeploy
 RPM_VERSION ?= $(shell head -1 .version)
-
+RPM_RELEASE ?= $(shell head -1 .rpm_release)
 BUILD_METADATA ?= "1~development~$(shell git rev-parse --short HEAD)"
 BUILD_DIR ?= $(PWD)/dist/rpmbuild
 
-CMSDEV_SPEC_NAME ?= ${NAME}-crayctldeploy
-CMSDEV_SPEC_FILE ?= ${CMSDEV_SPEC_NAME}.spec
-CMSDEV_SOURCE_NAME ?= ${CMSDEV_SPEC_NAME}-${RPM_VERSION}
+CMSDEV_SPEC_FILE ?= ${NAME}.spec
+CMSDEV_SOURCE_NAME ?= ${NAME}-${RPM_VERSION}-${RPM_RELEASE}
 CMSDEV_SOURCE_PATH := ${BUILD_DIR}/SOURCES/${CMSDEV_SOURCE_NAME}.tar.bz2
 
 all : runbuildprep lint prepare rpm

--- a/cray-cmstools-crayctldeploy.spec
+++ b/cray-cmstools-crayctldeploy.spec
@@ -24,10 +24,11 @@ Name: cray-cmstools-crayctldeploy
 License: MIT
 Summary: Cray CMS tests and tools
 Group: System/Management
-Version: %(cat .version)
-Release: %(echo ${BUILD_METADATA})
-Source: %{name}-%{version}.tar.bz2
-Vendor: Cray Inc.
+Version: @RPM_VERSION@
+Release: @RPM_RELEASE@
+Source: %{name}-%{version}-%{release}.tar.bz2
+Vendor: HPE
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires: make
 BuildRequires: go >= 1.13
 Requires: python3 >= 3.6
@@ -36,7 +37,7 @@ Requires: python3 >= 3.6
 Cray CMS tests and tools
 
 %prep
-%setup -q
+%setup -qn %{name}-%{version}-%{release}
 
 %build
 pushd cmsdev

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -15,4 +15,11 @@
 #sourcefile: v2.txt
 #targetfile: 1/2/3.txt
 
+sourcefile: .version
 targetfile: cmsdev/internal/cmd/version.go
+tag: @RPM_VERSION@
+targetfile: cray-cmstools-crayctldeploy.spec
+
+sourcefile-novalidate: .rpm_release
+tag: @RPM_RELEASE@
+targetfile: cray-cmstools-crayctldeploy.spec


### PR DESCRIPTION
## Summary and Scope

When I enabled git versioning for the repo I forgot to have it set the RPM release field, like what we had to do with BOS. This PR corrects that.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
