### PR TITLE
CASMCMS-8068: Allow user to specify ID of IMS image used for barebones boot test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Barebones boot test now allows user to specify ID of IMS image used for test
+
 ## [1.5.0] - 2022-07-25
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Currently the barebones boot test selects the first IMS image it finds with "barebones" in the name. In some cases, there may be multiple such images, and in other cases, an administrator may have removed or renamed the provided CSM barebones image. This PR adds an argument to the test allowing the user to specify the ID of an IMS image to be used, if desired.

## Testing

I tested this on rocket, both with and without an ID being specified, to make sure that both cases still work correctly. I also tested to make sure it behaved appropriately if an invalid ID is specified.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
