### PR TITLE
Release 1.6.1: CASMINST-5240: cmsdev: Disable BOS CLI testing without explicitly specifying BOS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2022-08-17
+
+### Removed
+
+- cmsdev: Removed testing of BOS CLI without explicitly specifying the version. For BOS, the CLI now defaults to BOSv2, but cmsdev has not yet been updated to support BOSv2.
+
 ## [1.6.0] - 2022-07-27
 
 ### Changed

--- a/cmsdev/internal/test/bos/bos.go
+++ b/cmsdev/internal/test/bos/bos.go
@@ -106,23 +106,18 @@ func IsBOSRunning() (passed bool) {
 	}
 
 	// Run basic API and CLI tests
-	// For CLI test both with and without specifying the version
+	// For CLI, currently only test by explicitly specifying v1. When support is added to cmsdev for BOSv2, that can be tested both
+	// by specifying v2 explicitly and by not specifying the version to the CLI.
 	if !versionTests() {
 		passed = false
 	}
 	if !sessionTemplateTestsAPI() {
 		passed = false
 	}
-	if !sessionTemplateTestsCLI(0) {
-		passed = false
-	}
 	if !sessionTemplateTestsCLI(1) {
 		passed = false
 	}
 	if !sessionTestsAPI() {
-		passed = false
-	}
-	if !sessionTestsCLI(0) {
 		passed = false
 	}
 	if !sessionTestsCLI(1) {


### PR DESCRIPTION
## Summary and Scope

The cmsdev test tool currently tests BOS CLI commands both with and without explicitly specifying the version. However, the tool has not yet been updated to know about BOS v2, and the CLI now defaults to BOS v2 when no version is explicitly specified. The syntax of the BOS v2 CLI commands is not identical to BOS v1, so this causes the test to fail when it tries to run CLI commands without a version explicitly specified.

This PR just removes the function calls that were testing the BOS CLI without explicitly specifying the version. This means it will only make BOS CLI calls by explicitly specifying BOS v1, thus avoiding the problem.

## Issues and Related PRs

- Resolves [CASMINST-5240](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5240)
- The "correct" fix for this is to update cmsdev so it can also test BOSv2. I have that work currently underway in [CASMCMS-8087](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8087).

## Testing

I tested the updated cmsdev tool on fanta (where this problem was originally reported) and verified that the test now passes:

```text
ncn-m001:/tmp/a # cmsdev test -q bos
Starting main run, version: 1.6.0, tag: 8ogTw
Starting sub-run, tag: 8ogTw-bos
ERROR (run tag 8ogTw-bos): CLI command failed (and does not look like a CLI config issue)
ERROR (run tag 8ogTw-bos): CLI command failed (and does not look like a CLI config issue)
Ended sub-run, tag: 8ogTw-bos (duration: 8.632969293s)
Ended run, tag: 8ogTw (duration: 8.644347472s)
FAILURE
ncn-m001:/tmp/a # rpm -Uvh *.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:cray-cmstools-crayctldeploy-1.6.1################################# [ 50%]
Cleaning up / removing...
   2:cray-cmstools-crayctldeploy-1.6.0################################# [100%]
ncn-m001:/tmp/a # cmsdev test -q bos
Starting main run, version: 1.6.1, tag: 3tyUL
Starting sub-run, tag: 3tyUL-bos
Ended sub-run, tag: 3tyUL-bos (duration: 6.118032766s)
Ended run, tag: 3tyUL (duration: 6.127770371s)
SUCCESS
ncn-m001:/tmp/a #
```

## Risks and Mitigations

Very low risk -- cmsdev just no longer calls a couple of its subtests. Nothing about the remaining tests has changed, and nothing that remains has any kind of dependency on any actions taken by the now-removed subtests.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
