### PR TITLE
CASMCMS-8087: Add BOSv2 support to cmsdev test tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- cmsdev: Add testing of BOSv2 (both API and CLI). Restored testing of CLI without explicitly specifying the BOS version.
-- cmsdev: Include CLI command that failed in corresponding error messages
+- cmsdev:
+  - Add testing of BOSv2 (both API and CLI), including the new BOSv2 `components` and `options`. Restored testing of CLI without explicitly specifying the BOS version.
+  - Include CLI command that failed in corresponding error messages.
+  - Add testing of BOS (v1 and v2) `healthz` endpoints and CLI.
 
 ## [1.6.1] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- cmsdev: Add testing of BOSv2 (both API and CLI). Restored testing of CLI without explicitly specifying the BOS version.
+
 ## [1.6.1] - 2022-08-17
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - cmsdev: Add testing of BOSv2 (both API and CLI). Restored testing of CLI without explicitly specifying the BOS version.
+- cmsdev: Include CLI command that failed in corresponding error messages
 
 ## [1.6.1] - 2022-08-17
 

--- a/cmsdev/internal/lib/common/helpers.go
+++ b/cmsdev/internal/lib/common/helpers.go
@@ -57,6 +57,15 @@ func DecodeJSONIntoStringList(listJsonBytes []byte) ([]string, error) {
 	return m, nil
 }
 
+func DecodeJSONIntoStringMapList(mapListJsonBytes []byte) ([]map[string]interface{}, error) {
+	var m []map[string]interface{}
+	err := json.Unmarshal(mapListJsonBytes, &m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 func GetStringFieldFromFirstItem(fieldName string, listJsonBytes []byte) (fieldValue string, err error) {
 	fieldValue = ""
 

--- a/cmsdev/internal/lib/test/cli.go
+++ b/cmsdev/internal/lib/test/cli.go
@@ -118,7 +118,7 @@ func RunCLICommand(cmdList ...string) []byte {
 		cmdResult, err = common.RunName("bash", "-c", baseCmdStr)
 		if err != nil {
 			common.Error(err)
-			common.Errorf("Error running CLI command")
+			common.Errorf("Error running CLI command (%s)", strings.Join(cmdList, " "))
 			return nil
 		} else if cmdResult.Rc == 0 {
 			return cmdResult.OutBytes
@@ -132,7 +132,7 @@ func RunCLICommand(cmdList ...string) []byte {
 			}
 		}
 		if !configError {
-			common.Errorf("CLI command failed (and does not look like a CLI config issue)")
+			common.Errorf("CLI command failed (and does not look like a CLI config issue) (%s)", strings.Join(cmdList, " "))
 			return nil
 		}
 		common.Debugf("CLI command failure looks like it may be a CLI config issue")
@@ -147,10 +147,10 @@ func RunCLICommand(cmdList ...string) []byte {
 	cmdResult, err = common.RunName("bash", "-c", cmdStr)
 	if err != nil {
 		common.Error(err)
-		common.Errorf("Error running CLI command")
+		common.Errorf("Error running CLI command (%s)", strings.Join(cmdList, " "))
 		return nil
 	} else if cmdResult.Rc != 0 {
-		common.Errorf("CLI command failed")
+		common.Errorf("CLI command failed (%s)", strings.Join(cmdList, " "))
 		return nil
 	}
 	if len(tmpCliConfigFile) > 0 {

--- a/cmsdev/internal/test/bos/bos.go
+++ b/cmsdev/internal/test/bos/bos.go
@@ -38,9 +38,6 @@ import (
 	"strings"
 )
 
-// CMS service endpoints
-var endpoints map[string]map[string]*common.Endpoint = common.GetEndpoints()
-
 func IsBOSRunning() (passed bool) {
 	passed = true
 
@@ -105,22 +102,13 @@ func IsBOSRunning() (passed bool) {
 		common.ArtifactsPodsPvcs(podNames, pvcNames)
 	}
 
-	// Run basic API and CLI tests
-	// For CLI, currently only test by explicitly specifying v1. When support is added to cmsdev for BOSv2, that can be tested both
-	// by specifying v2 explicitly and by not specifying the version to the CLI.
-	if !versionTests() {
+	// Defined in bos_api.go
+	if !apiTests() {
 		passed = false
 	}
-	if !sessionTemplateTestsAPI() {
-		passed = false
-	}
-	if !sessionTemplateTestsCLI(1) {
-		passed = false
-	}
-	if !sessionTestsAPI() {
-		passed = false
-	}
-	if !sessionTestsCLI(1) {
+
+	// Defined in bos_cli.go
+	if !cliTests() {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_api.go
+++ b/cmsdev/internal/test/bos/bos_api.go
@@ -42,10 +42,14 @@ const bosBaseUrl = common.BASEURL + "/apis/bos"
 const bosV1BaseUri = "/v1"
 const bosV2BaseUri = "/v2"
 
+// A wrapper for the common test.RestfulVerifyStatus function that converts a BOS URI into the full URL before
+// calling that function
 func bosRestfulVerifyStatus(method, uri string, params *common.Params, ExpectedStatus int) (*resty.Response, error) {
 	return test.RestfulVerifyStatus(method, bosBaseUrl+uri, *params, ExpectedStatus)
 }
 
+// Given a BOS URI, do a GET request to it. Verify that the response has 200 status code and returns a dictionary (aka string map) object.
+// Return true if all of that worked fine. Otherwise, log an appropriate error and return false.
 func basicGetUriVerifyStringMapTest(uri string, params *common.Params) bool {
 	common.Infof("GET %s test scenario", uri)
 	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
@@ -63,6 +67,7 @@ func basicGetUriVerifyStringMapTest(uri string, params *common.Params) bool {
 	return true
 }
 
+// Run all of the BOS API subtests. Return true if they all pass, false otherwise.
 func apiTests() (passed bool) {
 	passed = true
 

--- a/cmsdev/internal/test/bos/bos_cli.go
+++ b/cmsdev/internal/test/bos/bos_cli.go
@@ -36,21 +36,27 @@ import (
 	"strings"
 )
 
+// Wrapper function for test.RunCLICommandJSON. Prepends "bos" to a CLI command list and then runs it.
 func runBosCLI(cmdArgs ...string) []byte {
 	common.Infof("Testing BOS CLI (%s)", strings.Join(cmdArgs, " "))
 	return test.RunCLICommandJSON("bos", cmdArgs...)
 }
 
+// Wrapper function for runBosCLI. Append "list" to a CLI command list and then runs it.
 func runBosCLIList(cmdArgs ...string) []byte {
 	newCmdArgs := append(cmdArgs, "list")
 	return runBosCLI(newCmdArgs...)
 }
 
+// Wrapper function for runBosCLI. Append "describe <target>" to a CLI command list and then runs it.
 func runBosCLIDescribe(target string, cmdArgs ...string) []byte {
 	newCmdArgs := append(cmdArgs, "describe", target)
 	return runBosCLI(newCmdArgs...)
 }
 
+// Given a BOS CLI command prefix, run that CLI command with "list" appended to the end.
+// Verify that the command succeeded and returns a dictionary (aka string map) object.
+// Return true if all of that worked fine. Otherwise, log an appropriate error and return false.
 func basicCLIListVerifyStringMapTest(cmdArgs ...string) bool {
 	cmdOut := runBosCLIList(cmdArgs...)
 	if cmdOut == nil {
@@ -66,6 +72,9 @@ func basicCLIListVerifyStringMapTest(cmdArgs ...string) bool {
 	return true
 }
 
+// Given a BOS CLI command prefix and a target name, run that CLI command with "describe <target>" appended to the end.
+// Verify that the command succeeded and returns a dictionary (aka string map) object.
+// Return true if all of that worked fine. Otherwise, log an appropriate error and return false.
 func basicCLIDescribeVerifyStringMapTest(target string, cmdArgs ...string) bool {
 	cmdOut := runBosCLIDescribe(target, cmdArgs...)
 	if cmdOut == nil {
@@ -81,6 +90,7 @@ func basicCLIDescribeVerifyStringMapTest(target string, cmdArgs ...string) bool 
 	return true
 }
 
+// Run all of the BOS CLI subtests. Return true if they all pass, false otherwise.
 func cliTests() (passed bool) {
 	passed = true
 

--- a/cmsdev/internal/test/bos/bos_components.go
+++ b/cmsdev/internal/test/bos/bos_components.go
@@ -88,7 +88,7 @@ func ValidateComponentId(mapCmdOut []byte, expectedId string) bool {
 	return true
 }
 
-// component tests
+// See comment earler in file for a description of this function
 func componentsTestsURI(uri string, params *common.Params) bool {
 	// test #1, list components
 	common.Infof("GET %s test scenario", uri)
@@ -124,6 +124,7 @@ func componentsTestsURI(uri string, params *common.Params) bool {
 	return true
 }
 
+// See comment earler in file for a description of this function
 func componentsTestsCLICommand(cmdArgs ...string) bool {
 	// test #1, list components
 	cmdOut := runBosCLIList(cmdArgs...)

--- a/cmsdev/internal/test/bos/bos_components.go
+++ b/cmsdev/internal/test/bos/bos_components.go
@@ -1,0 +1,147 @@
+//
+//  MIT License
+//
+//  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+package bos
+
+/*
+ * bos_components.go
+ *
+ * bos component tests
+ *
+ */
+
+import (
+	"net/http"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+// components is new for BOS v2
+const bosV2ComponentsUri = bosV2BaseUri + "/components"
+
+const bosV2ComponentsCLI = "components"
+const bosDefaultComponentsCLI = bosV2ComponentsCLI
+
+func componentsTestsAPI(params *common.Params) (passed bool) {
+	passed = true
+
+	if !componentsTestsURI(bosV2ComponentsUri, params) {
+		passed = false
+	}
+
+	return
+}
+
+func componentsTestsCLI() (passed bool) {
+	passed = true
+
+	// v2
+	if !componentsTestsCLICommand("v2", bosV2ComponentsCLI) {
+		passed = false
+	}
+
+	// default (v2)
+	if !componentsTestsCLICommand(bosDefaultComponentsCLI) {
+		passed = false
+	}
+
+	return
+}
+
+func getFirstComponentId(listCmdOut []byte) (string, error) {
+	return common.GetStringFieldFromFirstItem("id", listCmdOut)
+}
+
+func ValidateComponentId(mapCmdOut []byte, expectedId string) bool {
+	err := common.ValidateStringFieldValue("BOS component", "id", expectedId, mapCmdOut)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+	return true
+}
+
+// component tests
+func componentsTestsURI(uri string, params *common.Params) bool {
+	// test #1, list components
+	common.Infof("GET %s test scenario", uri)
+	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// use results from previous test, grab the first component
+	componentId, err := getFirstComponentId(resp.Body())
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(componentId) == 0 {
+		common.Infof("skipping test GET %s/{component_id}", uri)
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// a component id is available
+	// test #2 describe component
+	uri += "/" + componentId
+	common.Infof("GET %s test scenario", uri)
+	resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if !ValidateComponentId(resp.Body(), componentId) {
+		return false
+	}
+
+	return true
+}
+
+func componentsTestsCLICommand(cmdArgs ...string) bool {
+	// test #1, list components
+	cmdOut := runBosCLIList(cmdArgs...)
+	if cmdOut == nil {
+		return false
+	}
+
+	// use results from previous test, grab the first component
+	componentId, err := getFirstComponentId(cmdOut)
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(componentId) == 0 {
+		common.Infof("skipping test CLI describe component {component_id}")
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// a component_id is available
+	// test #2 describe component
+	cmdOut = runBosCLIDescribe(componentId, cmdArgs...)
+	if cmdOut == nil {
+		return false
+	} else if !ValidateComponentId(cmdOut, componentId) {
+		return false
+	}
+
+	return true
+}

--- a/cmsdev/internal/test/bos/bos_components.go
+++ b/cmsdev/internal/test/bos/bos_components.go
@@ -41,6 +41,14 @@ const bosV2ComponentsUri = bosV2BaseUri + "/components"
 const bosV2ComponentsCLI = "components"
 const bosDefaultComponentsCLI = bosV2ComponentsCLI
 
+// The componentsTestsURI and componentsTestsCLICommand functions define the API and CLI versions of the BOS components subtests.
+// They both do the same thing:
+// 1. List all components
+// 2. Verify that this succeeds and returns something of the right general form
+// 3. If the list returned is empty, then the subtest is over. Otherwise, select the first element of the list and extract the "id" field
+// 4. Do a GET/describe on that particular component
+// 5. Verify that this succeeds and returns something of the right general form
+
 func componentsTestsAPI(params *common.Params) (passed bool) {
 	passed = true
 

--- a/cmsdev/internal/test/bos/bos_healthz.go
+++ b/cmsdev/internal/test/bos/bos_healthz.go
@@ -1,0 +1,85 @@
+//
+//  MIT License
+//
+//  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+package bos
+
+/*
+ * bos_healthz.go
+ *
+ * bos healthz tests
+ *
+ */
+
+import (
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+const bosV1HealthzUri = bosV1BaseUri + "/healthz"
+const bosV2HealthzUri = bosV2BaseUri + "/healthz"
+
+const bosV1HealthzCLI = "healthz"
+const bosV2HealthzCLI = "healthz"
+const bosDefaultHealthzCLI = bosV2HealthzCLI
+
+func healthzTestsAPI(params *common.Params) (passed bool) {
+	passed = true
+
+	if !healthzTestURI(bosV1HealthzUri, params) {
+		passed = false
+	}
+
+	if !healthzTestURI(bosV2HealthzUri, params) {
+		passed = false
+	}
+
+	return
+}
+
+func healthzTestsCLI() (passed bool) {
+	passed = true
+
+	// v1
+	if !healthzTestCLICommand("v1", bosV1HealthzCLI) {
+		passed = false
+	}
+
+	// v2
+	if !healthzTestCLICommand("v2", bosV2HealthzCLI) {
+		passed = false
+	}
+
+	// default (v2)
+	if !healthzTestCLICommand(bosDefaultHealthzCLI) {
+		passed = false
+	}
+
+	return
+}
+
+func healthzTestURI(uri string, params *common.Params) bool {
+	return basicGetUriVerifyStringMapTest(uri, params)
+}
+
+func healthzTestCLICommand(cmdArgs ...string) bool {
+	return basicCLIListVerifyStringMapTest(cmdArgs...)
+}

--- a/cmsdev/internal/test/bos/bos_healthz.go
+++ b/cmsdev/internal/test/bos/bos_healthz.go
@@ -44,11 +44,16 @@ const bosDefaultHealthzCLI = bosV2HealthzCLI
 func healthzTestsAPI(params *common.Params) (passed bool) {
 	passed = true
 
-	if !healthzTestURI(bosV1HealthzUri, params) {
+	// Just do a GET of the options endpoint and make sure that the response has
+	// 200 status and a dictionary object
+
+	// v1 endpoint
+	if !basicGetUriVerifyStringMapTest(bosV1HealthzUri, params) {
 		passed = false
 	}
 
-	if !healthzTestURI(bosV2HealthzUri, params) {
+	// v2 endpoint
+	if !basicGetUriVerifyStringMapTest(bosV2HealthzUri, params) {
 		passed = false
 	}
 
@@ -58,28 +63,22 @@ func healthzTestsAPI(params *common.Params) (passed bool) {
 func healthzTestsCLI() (passed bool) {
 	passed = true
 
-	// v1
-	if !healthzTestCLICommand("v1", bosV1HealthzCLI) {
+	// Make sure that "healthz list" CLI commmand succeeds and returns a dictionary object.
+
+	// "v1 healthz list"
+	if !basicCLIListVerifyStringMapTest("v1", bosV1HealthzCLI) {
 		passed = false
 	}
 
-	// v2
-	if !healthzTestCLICommand("v2", bosV2HealthzCLI) {
+	// "v2 healthz list"
+	if !basicCLIListVerifyStringMapTest("v2", bosV2HealthzCLI) {
 		passed = false
 	}
 
-	// default (v2)
-	if !healthzTestCLICommand(bosDefaultHealthzCLI) {
+	// "healthz list"
+	if !basicCLIListVerifyStringMapTest(bosDefaultHealthzCLI) {
 		passed = false
 	}
 
 	return
-}
-
-func healthzTestURI(uri string, params *common.Params) bool {
-	return basicGetUriVerifyStringMapTest(uri, params)
-}
-
-func healthzTestCLICommand(cmdArgs ...string) bool {
-	return basicCLIListVerifyStringMapTest(cmdArgs...)
 }

--- a/cmsdev/internal/test/bos/bos_options.go
+++ b/cmsdev/internal/test/bos/bos_options.go
@@ -43,7 +43,9 @@ const bosDefaultOptionsCLI = bosV2OptionsCLI
 func optionsTestsAPI(params *common.Params) (passed bool) {
 	passed = true
 
-	if !optionsTestURI(bosV2OptionsUri, params) {
+	// Just do a GET of the options endpoint and make sure that the response has
+	// 200 status and a dictionary object
+	if !basicGetUriVerifyStringMapTest(bosV2OptionsUri, params) {
 		passed = false
 	}
 
@@ -53,23 +55,17 @@ func optionsTestsAPI(params *common.Params) (passed bool) {
 func optionsTestsCLI() (passed bool) {
 	passed = true
 
-	// v2
-	if !optionsTestCLICommand("v2", bosV2OptionsCLI) {
+	// Make sure that "options list" CLI commmand succeeds and returns a dictionary object.
+	
+	// "v2 options list"
+	if !basicCLIListVerifyStringMapTest("v2", bosV2OptionsCLI) {
 		passed = false
 	}
 
-	// default (v2)
-	if !optionsTestCLICommand(bosDefaultOptionsCLI) {
+	// "options list"
+	if !basicCLIListVerifyStringMapTest(bosDefaultOptionsCLI) {
 		passed = false
 	}
 
 	return
-}
-
-func optionsTestURI(uri string, params *common.Params) bool {
-	return basicGetUriVerifyStringMapTest(uri, params)
-}
-
-func optionsTestCLICommand(cmdArgs ...string) bool {
-	return basicCLIListVerifyStringMapTest(cmdArgs...)
 }

--- a/cmsdev/internal/test/bos/bos_options.go
+++ b/cmsdev/internal/test/bos/bos_options.go
@@ -1,0 +1,75 @@
+//
+//  MIT License
+//
+//  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included
+//  in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+//  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+//  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+//  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+package bos
+
+/*
+ * bos_options.go
+ *
+ * bos options tests
+ *
+ */
+
+import (
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+// Options are new in BOS v2
+const bosV2OptionsUri = bosV2BaseUri + "/options"
+
+const bosV2OptionsCLI = "options"
+const bosDefaultOptionsCLI = bosV2OptionsCLI
+
+func optionsTestsAPI(params *common.Params) (passed bool) {
+	passed = true
+
+	if !optionsTestURI(bosV2OptionsUri, params) {
+		passed = false
+	}
+
+	return
+}
+
+func optionsTestsCLI() (passed bool) {
+	passed = true
+
+	// v2
+	if !optionsTestCLICommand("v2", bosV2OptionsCLI) {
+		passed = false
+	}
+
+	// default (v2)
+	if !optionsTestCLICommand(bosDefaultOptionsCLI) {
+		passed = false
+	}
+
+	return
+}
+
+func optionsTestURI(uri string, params *common.Params) bool {
+	return basicGetUriVerifyStringMapTest(uri, params)
+}
+
+func optionsTestCLICommand(cmdArgs ...string) bool {
+	return basicCLIListVerifyStringMapTest(cmdArgs...)
+}

--- a/cmsdev/internal/test/bos/bos_options.go
+++ b/cmsdev/internal/test/bos/bos_options.go
@@ -56,7 +56,7 @@ func optionsTestsCLI() (passed bool) {
 	passed = true
 
 	// Make sure that "options list" CLI commmand succeeds and returns a dictionary object.
-	
+
 	// "v2 options list"
 	if !basicCLIListVerifyStringMapTest("v2", bosV2OptionsCLI) {
 		passed = false

--- a/cmsdev/internal/test/bos/bos_session.go
+++ b/cmsdev/internal/test/bos/bos_session.go
@@ -42,6 +42,16 @@ const bosV1SessionsCLI = "session"
 const bosV2SessionsCLI = "sessions"
 const bosDefaultSessionsCLI = bosV2SessionsCLI
 
+// The sessionsV1TestsURI, sessionsV2TestsURI, sessionsV1TestsCLICommand, and sessionsV2TestsCLICommand functions define the API and CLI versions of the
+// BOS v1 and v2 session subtests.
+// They all do essentially the same thing:
+// 1. List all sessions
+// 2. Verify that this succeeds and returns something of the right general form (for v1, this is expected to be a list of strings,
+//    whereas for v2 this should be a list of dictionary objects)
+// 3. If the list returned is empty, then the subtest is over. Otherwise, select the first element of the list. (If bosV2, extract the "name" field of that element).
+// 4. Do a GET/describe on that particular session
+// 5. Verify that this succeeds and returns something of the right general form, which has the expected session ID (v1) or name (v2)
+
 func sessionsTestsAPI(params *common.Params) (passed bool) {
 	passed = true
 

--- a/cmsdev/internal/test/bos/bos_session.go
+++ b/cmsdev/internal/test/bos/bos_session.go
@@ -33,105 +33,223 @@ package bos
 import (
 	"net/http"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
-	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
 )
 
-// session tests
-func sessionTestsAPI() bool {
-	var baseurl string = common.BASEURL
-	const totalNumTests int = 1
+const bosV1SessionsUri = bosV1BaseUri + "/session"
+const bosV2SessionsUri = bosV2BaseUri + "/sessions"
 
-	numTests, numTestsFailed := 0, 0
-	params := test.GetAccessTokenParams()
-	if params == nil {
+const bosV1SessionsCLI = "session"
+const bosV2SessionsCLI = "sessions"
+const bosDefaultSessionsCLI = bosV2SessionsCLI
+
+func sessionsTestsAPI(params *common.Params) (passed bool) {
+	passed = true
+
+	// v1 sessions
+	if !sessionsV1TestsURI(bosV1SessionsUri, params) {
+		passed = false
+	}
+
+	// v2 sessions
+	if !sessionsV2TestsURI(bosV2SessionsUri, params) {
+		passed = false
+	}
+
+	return
+}
+
+func sessionsTestsCLI() (passed bool) {
+	passed = true
+
+	// v1 sessions
+	if !sessionsV1TestsCLICommand("v1", bosV1SessionsCLI) {
+		passed = false
+	}
+
+	// v2 sessions
+	if !sessionsV2TestsCLICommand("v2", bosV2SessionsCLI) {
+		passed = false
+	}
+
+	// default (v2) sessions
+	if !sessionsV2TestsCLICommand(bosDefaultSessionsCLI) {
+		passed = false
+	}
+
+	return
+}
+
+// v1 sessions API tests
+func sessionsV1TestsURI(uri string, params *common.Params) bool {
+	// test #1, list session
+	common.Infof("GET %s test scenario", uri)
+	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
 		return false
 	}
 
-	// test #1, list session
-	url := baseurl + endpoints["bos"]["session"].Url
-	numTests++
-	test.RestfulTestHeader("GET session", numTests, totalNumTests)
-	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+	// BOS v1: Validate that at least we can decode the JSON into a list of strings
+	stringList, err := common.DecodeJSONIntoStringList(resp.Body())
 	if err != nil {
 		common.Error(err)
-		numTestsFailed++
-	} else {
-		// Validate that at least we can decode the JSON into a list of strings
-		stringList, err := common.DecodeJSONIntoStringList(resp.Body())
-		if err != nil {
-			common.Error(err)
-			numTestsFailed++
-		} else if len(stringList) == 0 {
-			common.VerbosePrintDivider()
-			common.Infof("skipping test GET /session/{session_id}")
-			common.Infof("results from previous test is []")
-		} else {
-			// a session_id is available
-			sessionId := stringList[0]
-
-			url = baseurl + endpoints["bos"]["session"].Url + "/" + sessionId
-			numTests++
-			test.RestfulTestHeader("GET session_id", numTests, totalNumTests)
-			resp, err = test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
-			if err != nil {
-				common.Error(err)
-				numTestsFailed++
-			} else {
-				// Validate that the session can at least be decoded into a string map
-				_, err = common.DecodeJSONIntoStringMap(resp.Body())
-				if err != nil {
-					common.Error(err)
-					numTestsFailed++
-				}
-			}
-		}
-		// TODO: deeper validation of returned response
+		return false
+	} else if len(stringList) == 0 {
+		common.Infof("skipping test GET %s/{session_id}", uri)
+		common.Infof("results from previous test is []")
+		return true
 	}
 
-	test.RestfulTestResultSummary(numTestsFailed, numTests)
-	return numTestsFailed == 0
+	// a session_id is available
+	sessionId := stringList[0]
+	common.Infof("Found BOS v1 session with ID '%s'", sessionId)
+
+	// test #2, describe session with session_id
+	uri += "/" + sessionId
+	if !basicGetUriVerifyStringMapTest(uri, params) {
+		return false
+	}
+
+	return true
 }
 
-func sessionTestsCLI(vnum int) bool {
-	// test #1, list session
-	common.Infof("Getting list of all BOS sessions via CLI")
-	cmdOut := runCLICommand(vnum, "session", "list")
+func ValidateV2Session(mapCmdOut []byte, expectedName string) bool {
+	// For BOSv2, the session object we get back should have a 'name' field matching the name that we requested.
+	// So let's validate that
+	err := common.ValidateStringFieldValue("BOS session", "name", expectedName, mapCmdOut)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+	return true
+}
+
+// v2 sessions API tests
+func sessionsV2TestsURI(uri string, params *common.Params) bool {
+	// test #1, list sessions
+	common.Infof("GET %s test scenario", uri)
+	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// BOS v2: Decode JSON into a list
+	sessionList, err := common.DecodeJSONIntoList(resp.Body())
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(sessionList) == 0 {
+		common.Infof("skipping test GET %s/{session_id}", uri)
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// Take the first session listed. It should be a dictionary object.
+	sessionObject := sessionList[0]
+	session, ok := sessionObject.(map[string]interface{})
+	if !ok {
+		common.Errorf("First BOS session listed is not a dictionary object: %v", sessionObject)
+		return false
+	}
+
+	common.Debugf("Getting 'name' field BOS session: %v", session)
+	sessionId, err := common.GetStringFieldFromMapObject("name", session)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+	common.Infof("Found BOS v2 session with name '%s'", sessionId)
+
+	// test #2: describe session
+	uri += "/" + sessionId
+	resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if !ValidateV2Session(resp.Body(), sessionId) {
+		return false
+	}
+
+	return true
+}
+
+// v1 sessions CLI tests
+func sessionsV1TestsCLICommand(cmdArgs ...string) bool {
+	// test #1, list sessions
+	cmdOut := runBosCLIList(cmdArgs...)
 	if cmdOut == nil {
 		return false
 	}
 
-	// Validate that at least we can decode the JSON into a list of strings
+	// BOS v1: Validate that at least we can decode the JSON into a list of strings
 	stringList, err := common.DecodeJSONIntoStringList(cmdOut)
 	if err != nil {
 		common.Error(err)
 		return false
 	}
 
-	// test #2, list session with session_id
-	// use results from previous tests, grab the first session
+	// Grab the first session ID
 	if len(stringList) == 0 {
-		common.VerbosePrintDivider()
-		common.Infof("skipping test CLI describe sessiontemplate {session_template_id}")
+		common.Infof("skipping test CLI describe {session_id}")
 		common.Infof("results from previous test is []")
 		return true
 	}
 
 	// A session id is available
 	sessionId := stringList[0]
+	common.Infof("Found BOS v1 session with ID '%s'", sessionId)
 
-	common.Infof("Describing BOS session %s via CLI", sessionId)
-	cmdOut = runCLICommand(vnum, "session", "describe", sessionId)
+	// test #2, describe session with session_id
+	if !basicCLIDescribeVerifyStringMapTest(sessionId, cmdArgs...) {
+		return false
+	}
+
+	return true
+}
+
+// v2 sessions CLI tests
+func sessionsV2TestsCLICommand(cmdArgs ...string) bool {
+	// test #1, list sessions
+	cmdOut := runBosCLIList(cmdArgs...)
 	if cmdOut == nil {
 		return false
 	}
 
-	// Validate that the session can at least be decoded into a string map
-	_, err = common.DecodeJSONIntoStringMap(cmdOut)
+	// BOS v2: Decode JSON into a list
+	sessionList, err := common.DecodeJSONIntoList(cmdOut)
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(sessionList) == 0 {
+		common.Infof("skipping test CLI describe {session_id}")
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// Take the first session listed. It should be a dictionary object.
+	sessionObject := sessionList[0]
+	session, ok := sessionObject.(map[string]interface{})
+	if !ok {
+		common.Errorf("First BOS session listed is not a dictionary object: %v", sessionObject)
+		return false
+	}
+
+	common.Debugf("Getting 'name' field BOS session: %v", session)
+	sessionId, err := common.GetStringFieldFromMapObject("name", session)
 	if err != nil {
 		common.Error(err)
 		return false
 	}
+	common.Infof("Found BOS v2 session with name '%s'", sessionId)
 
-	// TODO: deeper validation of returned response
+	// test #2, describe session with session_id
+	cmdOut = runBosCLIDescribe(sessionId, cmdArgs...)
+	if cmdOut == nil {
+		return false
+	} else if !ValidateV2Session(cmdOut, sessionId) {
+		return false
+	}
+
 	return true
 }

--- a/cmsdev/internal/test/bos/bos_session.go
+++ b/cmsdev/internal/test/bos/bos_session.go
@@ -90,6 +90,7 @@ func sessionsTestsCLI() (passed bool) {
 }
 
 // v1 sessions API tests
+// See comment earlier in the file for a description of this function
 func sessionsV1TestsURI(uri string, params *common.Params) bool {
 	// test #1, list session
 	common.Infof("GET %s test scenario", uri)
@@ -123,6 +124,12 @@ func sessionsV1TestsURI(uri string, params *common.Params) bool {
 	return true
 }
 
+// Given a response object (as an array of bytes), validate that:
+// 1. It resolves to a JSON dictonary
+// 2. That dictionary has a "name" field
+// 3. The "name" field of that dictionary has a value which matches our expectedName string
+//
+// Return true if all of the above is true. Otherwise, log an appropriate error and return false.
 func ValidateV2Session(mapCmdOut []byte, expectedName string) bool {
 	// For BOSv2, the session object we get back should have a 'name' field matching the name that we requested.
 	// So let's validate that
@@ -135,6 +142,7 @@ func ValidateV2Session(mapCmdOut []byte, expectedName string) bool {
 }
 
 // v2 sessions API tests
+// See comment earlier in the file for a description of this function
 func sessionsV2TestsURI(uri string, params *common.Params) bool {
 	// test #1, list sessions
 	common.Infof("GET %s test scenario", uri)
@@ -185,6 +193,7 @@ func sessionsV2TestsURI(uri string, params *common.Params) bool {
 }
 
 // v1 sessions CLI tests
+// See comment earlier in the file for a description of this function
 func sessionsV1TestsCLICommand(cmdArgs ...string) bool {
 	// test #1, list sessions
 	cmdOut := runBosCLIList(cmdArgs...)
@@ -219,6 +228,7 @@ func sessionsV1TestsCLICommand(cmdArgs ...string) bool {
 }
 
 // v2 sessions CLI tests
+// See comment earlier in the file for a description of this function
 func sessionsV2TestsCLICommand(cmdArgs ...string) bool {
 	// test #1, list sessions
 	cmdOut := runBosCLIList(cmdArgs...)

--- a/cmsdev/internal/test/bos/bos_sessiontemplate.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate.go
@@ -33,8 +33,83 @@ package bos
 import (
 	"net/http"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
-	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
 )
+
+const bosV1SessionTemplatesUri = bosV1BaseUri + "/sessiontemplate"
+const bosV2SessionTemplatesUri = bosV2BaseUri + "/sessiontemplates"
+
+const bosV1SessionTemplateTemplateUri = bosV1BaseUri + "/sessiontemplatetemplate"
+const bosV2SessionTemplateTemplateUri = bosV2BaseUri + "/sessiontemplatetemplate"
+
+const bosV1SessionTemplatesCLI = "sessiontemplate"
+const bosV2SessionTemplatesCLI = "sessiontemplates"
+const bosDefaultSessionTemplatesCLI = bosV2SessionTemplatesCLI
+
+const bosV1SessionTemplateTemplateCLI = "sessiontemplatetemplate"
+const bosV2SessionTemplateTemplateCLI = "sessiontemplatetemplate"
+const bosDefaultSessionTemplateTemplateCLI = bosV2SessionTemplateTemplateCLI
+
+func sessionTemplatesTestsAPI(params *common.Params) (passed bool) {
+	passed = true
+
+	// v1 session template template
+	if !sessionTemplateTemplateTestURI(bosV1SessionTemplateTemplateUri, params) {
+		passed = false
+	}
+
+	// v2 session template template
+	if !sessionTemplateTemplateTestURI(bosV2SessionTemplateTemplateUri, params) {
+		passed = false
+	}
+
+	// v1 session templates
+	if !sessionTemplatesTestsURI(bosV1SessionTemplatesUri, params) {
+		passed = false
+	}
+
+	// v2 session templates
+	if !sessionTemplatesTestsURI(bosV2SessionTemplatesUri, params) {
+		passed = false
+	}
+
+	return
+}
+
+func sessionTemplatesTestsCLI() (passed bool) {
+	passed = true
+
+	// v1 session template template
+	if !sessionTemplateTemplateTestCLICommand("v1", bosV1SessionTemplateTemplateCLI) {
+		passed = false
+	}
+
+	// v2 session template template
+	if !sessionTemplateTemplateTestCLICommand("v2", bosV2SessionTemplateTemplateCLI) {
+		passed = false
+	}
+
+	// default (v2) session template template
+	if !sessionTemplateTemplateTestCLICommand(bosDefaultSessionTemplateTemplateCLI) {
+		passed = false
+	}
+
+	// v1 session templates
+	if !sessionTemplatesTestsCLICommand("v1", bosV1SessionTemplatesCLI) {
+		passed = false
+	}
+
+	// v2 session templates
+	if !sessionTemplatesTestsCLICommand("v2", bosV2SessionTemplatesCLI) {
+		passed = false
+	}
+
+	// default (v2) session templates
+	if !sessionTemplatesTestsCLICommand(bosDefaultSessionTemplatesCLI) {
+		passed = false
+	}
+
+	return
+}
 
 func getFirstSessionTemplateId(listCmdOut []byte) (string, error) {
 	return common.GetStringFieldFromFirstItem("name", listCmdOut)
@@ -49,125 +124,78 @@ func ValidateSessionTemplateId(mapCmdOut []byte, expectedName string) bool {
 	return true
 }
 
-// sessiontemplate tests
-func sessionTemplateTestsAPI() bool {
-	var baseurl string = common.BASEURL
-	const totalNumTests int = 2
+// sessiontemplatetemplate API test
+func sessionTemplateTemplateTestURI(uri string, params *common.Params) bool {
+	return basicGetUriVerifyStringMapTest(uri, params)
+}
 
-	numTests, numTestsFailed := 0, 0
-	params := test.GetAccessTokenParams()
-	if params == nil {
-		return false
-	}
+// sessiontemplatetemplate CLI test
+func sessionTemplateTemplateTestCLICommand(cmdArgs ...string) bool {
+	return basicCLIListVerifyStringMapTest(cmdArgs...)
+}
 
-	// test #1, get session template template
-	url := baseurl + endpoints["bos"]["sessiontemplatetemplate"].Url
-	numTests++
-	test.RestfulTestHeader("GET sessiontemplatetemplate", numTests, totalNumTests)
-	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
-	if err != nil {
-		common.Error(err)
-		numTestsFailed++
-	} else {
-		// Validate that we can decode it into a map object
-		_, err = common.DecodeJSONIntoStringMap(resp.Body())
-		if err != nil {
-			common.Error(err)
-			numTestsFailed++
-		}
-		// TODO: deeper validation of returned response
-	}
-
-	// test #2, list session templates
-	url = baseurl + endpoints["bos"]["sessiontemplate"].Url
-	numTests++
-	test.RestfulTestHeader("GET sessiontemplate", numTests, totalNumTests)
-	resp, err = test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+// session templates API tests
+func sessionTemplatesTestsURI(uri string, params *common.Params) bool {
+	// test #1, list session templates
+	common.Infof("GET %s test scenario", uri)
+	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
 		return false
 	}
-	// TODO: deeper validation of returned response
 
-	// test #3, list sessiontemplate with session_template_id
-	// use results from previous tests, grab the first sessiontemplate
+	// use results from previous test, grab the first session template
 	sessionTemplateId, err := getFirstSessionTemplateId(resp.Body())
 	if err != nil {
 		common.Error(err)
 		return false
 	} else if len(sessionTemplateId) == 0 {
-		common.VerbosePrintDivider()
-		common.Infof("skipping test GET /sessiontemplate/{session_template_id}")
+		common.Infof("skipping test GET %s/{session_template_id}", uri)
 		common.Infof("results from previous test is []")
-		return numTestsFailed == 0
+		return true
 	}
 
 	// a session_template_id is available
-	url = baseurl + endpoints["bos"]["sessiontemplate"].Url + "/" + sessionTemplateId
-	numTests++
-	test.RestfulTestHeader("GET session_template_id", numTests, totalNumTests)
-	resp, err = test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+	uri += "/" + sessionTemplateId
+	common.Infof("GET %s test scenario", uri)
+	resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
-		numTestsFailed++
+		return false
 	} else if !ValidateSessionTemplateId(resp.Body(), sessionTemplateId) {
-		numTestsFailed++
+		return false
 	}
 
-	// TODO: deeper validation of returned response
-
-	return numTestsFailed == 0
+	return true
 }
 
-func sessionTemplateTestsCLI(vnum int) bool {
-	var err error
-	var numTestsFailed = 0
-
-	// test #1, get example session template
-	common.Infof("Getting example BOS session template via CLI")
-	cmdOut := runCLICommand(vnum, "sessiontemplatetemplate", "list")
-	if cmdOut == nil {
-		numTestsFailed++
-	} else {
-		// Validate that we can decode it into a map object
-		_, err = common.DecodeJSONIntoStringMap(cmdOut)
-		if err != nil {
-			common.Error(err)
-			numTestsFailed++
-		}
-		// TODO: deeper validation of returned response
-	}
-
-	// test #2, list session templates
-	common.Infof("Getting list of all BOS session templates via CLI")
-	cmdOut = runCLICommand(vnum, "sessiontemplate", "list")
+// session templates CLI tests
+func sessionTemplatesTestsCLICommand(cmdArgs ...string) bool {
+	// test #1, list session templates
+	cmdOut := runBosCLIList(cmdArgs...)
 	if cmdOut == nil {
 		return false
 	}
-	// TODO: deeper validation of returned response
 
-	// test #3, list sessiontemplate with session_template_id
-	// use results from previous tests, grab the first sessiontemplate
+	// use results from previous test, grab the first session template
 	sessionTemplateId, err := getFirstSessionTemplateId(cmdOut)
 	if err != nil {
 		common.Error(err)
 		return false
 	} else if len(sessionTemplateId) == 0 {
-		common.VerbosePrintDivider()
-		common.Infof("skipping test CLI describe sessiontemplate {session_template_id}")
+		common.Infof("skipping test CLI describe component {session_template_id}")
 		common.Infof("results from previous test is []")
-		return numTestsFailed == 0
+		return true
 	}
 
-	// a session_template_id is available
-	common.Infof("Describing BOS session template %s via CLI", sessionTemplateId)
-	cmdOut = runCLICommand(vnum, "sessiontemplate", "describe", sessionTemplateId)
+	// a session template id is available
+	// test #2 describe session templates
+	cmdOut = runBosCLIDescribe(sessionTemplateId, cmdArgs...)
 	if cmdOut == nil {
 		return false
 	} else if !ValidateSessionTemplateId(cmdOut, sessionTemplateId) {
 		return false
 	}
 
-	// TODO: deeper validation of returned response
-	return numTestsFailed == 0
+	return true
 }

--- a/cmsdev/internal/test/bos/bos_sessiontemplate.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate.go
@@ -49,25 +49,39 @@ const bosV1SessionTemplateTemplateCLI = "sessiontemplatetemplate"
 const bosV2SessionTemplateTemplateCLI = "sessiontemplatetemplate"
 const bosDefaultSessionTemplateTemplateCLI = bosV2SessionTemplateTemplateCLI
 
+// The sessionTemplatesTestsURI and sessionTemplatesTestsCLICommand functions define the API and CLI versions of the BOS session template subtests.
+// They both do the same thing:
+// 1. List all session templates
+// 2. Verify that this succeeds and returns something of the right general form
+// 3. If the list returned is empty, then the subtest is over. Otherwise, select the first element of the list and extract the "name" field
+// 4. Do a GET/describe on that particular session template
+// 5. Verify that this succeeds and returns something of the right general form
+
 func sessionTemplatesTestsAPI(params *common.Params) (passed bool) {
 	passed = true
 
-	// v1 session template template
-	if !sessionTemplateTemplateTestURI(bosV1SessionTemplateTemplateUri, params) {
+	// session template template API tests
+	// Just do a GET of the sessiontemplatetemplate endpoint and make sure that the response has
+	// 200 status and a dictionary object
+
+	// v1
+	if !basicGetUriVerifyStringMapTest(bosV1SessionTemplateTemplateUri, params) {
 		passed = false
 	}
 
-	// v2 session template template
-	if !sessionTemplateTemplateTestURI(bosV2SessionTemplateTemplateUri, params) {
+	// v2
+	if !basicGetUriVerifyStringMapTest(bosV2SessionTemplateTemplateUri, params) {
 		passed = false
 	}
 
-	// v1 session templates
+	// session template API tests
+
+	// v1
 	if !sessionTemplatesTestsURI(bosV1SessionTemplatesUri, params) {
 		passed = false
 	}
 
-	// v2 session templates
+	// v2
 	if !sessionTemplatesTestsURI(bosV2SessionTemplatesUri, params) {
 		passed = false
 	}
@@ -78,32 +92,37 @@ func sessionTemplatesTestsAPI(params *common.Params) (passed bool) {
 func sessionTemplatesTestsCLI() (passed bool) {
 	passed = true
 
-	// v1 session template template
-	if !sessionTemplateTemplateTestCLICommand("v1", bosV1SessionTemplateTemplateCLI) {
+	// session template template CLI tests
+	// Make sure that "sessiontemplatetemplate list" CLI commmand succeeds and returns a dictionary object.
+
+	// v1 sessiontemplatetemplate list
+	if !basicCLIListVerifyStringMapTest("v1", bosV1SessionTemplateTemplateCLI) {
 		passed = false
 	}
 
-	// v2 session template template
-	if !sessionTemplateTemplateTestCLICommand("v2", bosV2SessionTemplateTemplateCLI) {
+	// v2 sessiontemplatetemplate list
+	if !basicCLIListVerifyStringMapTest("v2", bosV2SessionTemplateTemplateCLI) {
 		passed = false
 	}
 
-	// default (v2) session template template
-	if !sessionTemplateTemplateTestCLICommand(bosDefaultSessionTemplateTemplateCLI) {
+	// sessiontemplatetemplate list
+	if !basicCLIListVerifyStringMapTest(bosDefaultSessionTemplateTemplateCLI) {
 		passed = false
 	}
 
-	// v1 session templates
+	// session template CLI tests
+
+	// v1 sessiontemplate
 	if !sessionTemplatesTestsCLICommand("v1", bosV1SessionTemplatesCLI) {
 		passed = false
 	}
 
-	// v2 session templates
+	// v2 sessiontemplates
 	if !sessionTemplatesTestsCLICommand("v2", bosV2SessionTemplatesCLI) {
 		passed = false
 	}
 
-	// default (v2) session templates
+	// sessiontemplates
 	if !sessionTemplatesTestsCLICommand(bosDefaultSessionTemplatesCLI) {
 		passed = false
 	}
@@ -122,16 +141,6 @@ func ValidateSessionTemplateId(mapCmdOut []byte, expectedName string) bool {
 		return false
 	}
 	return true
-}
-
-// sessiontemplatetemplate API test
-func sessionTemplateTemplateTestURI(uri string, params *common.Params) bool {
-	return basicGetUriVerifyStringMapTest(uri, params)
-}
-
-// sessiontemplatetemplate CLI test
-func sessionTemplateTemplateTestCLICommand(cmdArgs ...string) bool {
-	return basicCLIListVerifyStringMapTest(cmdArgs...)
 }
 
 // session templates API tests
@@ -183,7 +192,7 @@ func sessionTemplatesTestsCLICommand(cmdArgs ...string) bool {
 		common.Error(err)
 		return false
 	} else if len(sessionTemplateId) == 0 {
-		common.Infof("skipping test CLI describe component {session_template_id}")
+		common.Infof("skipping test CLI describe session template {session_template_id}")
 		common.Infof("results from previous test is []")
 		return true
 	}

--- a/cmsdev/internal/test/bos/bos_sessiontemplate.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate.go
@@ -130,10 +130,22 @@ func sessionTemplatesTestsCLI() (passed bool) {
 	return
 }
 
+// Given a response object (as an array of bytes), do the following:
+// 1. Verify that it is a JSON list object
+// 2. If the list object is empty, return a blank string.
+// 3. If the list is not empty, verify that its first element is a dictionary.
+// 4. Look up the "name" key in that dictionary, and return its value.
+// If any of the above does not work, return an appropriate error.
 func getFirstSessionTemplateId(listCmdOut []byte) (string, error) {
 	return common.GetStringFieldFromFirstItem("name", listCmdOut)
 }
 
+// Given a response object (as an array of bytes), validate that:
+// 1. It resolves to a JSON dictonary
+// 2. That dictionary has a "name" field
+// 3. The "name" field of that dictionary has a value which matches our expectedName string
+//
+// Return true if all of the above is true. Otherwise, log an appropriate error and return false.
 func ValidateSessionTemplateId(mapCmdOut []byte, expectedName string) bool {
 	err := common.ValidateStringFieldValue("BOS sessiontemplate", "name", expectedName, mapCmdOut)
 	if err != nil {
@@ -144,6 +156,7 @@ func ValidateSessionTemplateId(mapCmdOut []byte, expectedName string) bool {
 }
 
 // session templates API tests
+// See comment earlier in the file for a description of this function
 func sessionTemplatesTestsURI(uri string, params *common.Params) bool {
 	// test #1, list session templates
 	common.Infof("GET %s test scenario", uri)
@@ -179,6 +192,7 @@ func sessionTemplatesTestsURI(uri string, params *common.Params) bool {
 }
 
 // session templates CLI tests
+// See comment earlier in the file for a description of this function
 func sessionTemplatesTestsCLICommand(cmdArgs ...string) bool {
 	// test #1, list session templates
 	cmdOut := runBosCLIList(cmdArgs...)

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -47,7 +47,7 @@ const bosDefaultVersionCLI = bosV2VersionCLI
 
 func versionTestsAPI(params *common.Params) (passed bool) {
 	passed = true
-	
+
 	// / endpoint
 	// Verify that a GET to this endpoint returns status 200 and a list of dictionary objects
 	if !versionListTestAPI(params) {

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -47,23 +47,34 @@ const bosDefaultVersionCLI = bosV2VersionCLI
 
 func versionTestsAPI(params *common.Params) (passed bool) {
 	passed = true
+	
+	// / endpoint
+	// Verify that a GET to this endpoint returns status 200 and a list of dictionary objects
 	if !versionListTestAPI(params) {
 		passed = false
 	}
 
-	if !versionTestURI(bosV1BaseUri, params) {
+	// For the remaining endpoints:
+	// Do a GET of the version endpoint and make sure that the response has
+	// 200 status and a dictionary object
+
+	// /v1 endpoint
+	if !basicGetUriVerifyStringMapTest(bosV1BaseUri, params) {
 		passed = false
 	}
 
-	if !versionTestURI(bosV1VersionUri, params) {
+	// /v1/version endpoint
+	if !basicGetUriVerifyStringMapTest(bosV1VersionUri, params) {
 		passed = false
 	}
 
-	if !versionTestURI(bosV2BaseUri, params) {
+	// /v2 endpoint
+	if !basicGetUriVerifyStringMapTest(bosV2BaseUri, params) {
 		passed = false
 	}
 
-	if !versionTestURI(bosV2VersionUri, params) {
+	// /v2/version endpoint
+	if !basicGetUriVerifyStringMapTest(bosV2VersionUri, params) {
 		passed = false
 	}
 
@@ -73,18 +84,20 @@ func versionTestsAPI(params *common.Params) (passed bool) {
 func versionTestsCLI() (passed bool) {
 	passed = true
 
-	// v1
-	if !versionTestCLICommand("v1", bosV1VersionCLI) {
+	// Make sure that "version list" CLI commmand succeeds and returns a dictionary object.
+
+	// v1 version list
+	if !basicCLIListVerifyStringMapTest("v1", bosV1VersionCLI) {
 		passed = false
 	}
 
-	// v2
-	if !versionTestCLICommand("v2", bosV2VersionCLI) {
+	// v2 version list
+	if !basicCLIListVerifyStringMapTest("v2", bosV2VersionCLI) {
 		passed = false
 	}
 
-	// default (v2)
-	if !versionTestCLICommand(bosDefaultVersionCLI) {
+	// version list
+	if !basicCLIListVerifyStringMapTest(bosDefaultVersionCLI) {
 		passed = false
 	}
 
@@ -107,12 +120,4 @@ func versionListTestAPI(params *common.Params) bool {
 		return false
 	}
 	return true
-}
-
-func versionTestURI(uri string, params *common.Params) bool {
-	return basicGetUriVerifyStringMapTest(uri, params)
-}
-
-func versionTestCLICommand(cmdArgs ...string) bool {
-	return basicCLIListVerifyStringMapTest(cmdArgs...)
 }


### PR DESCRIPTION
## Summary and Scope

The primary purpose of this PR was to add BOS v2 test coverage to the cmsdev test tool. While doing that, I did a minor overhaul of the cmsdev BOS CLI and API testing. It had a lot of cruft and I didn't like the idea of having the new API/CLI tests totally different from the old ones, but I also didn't like the idea of making the new ones have to match the old ones. So I just re-wrote all of them.

These are fairly basic tests. Mostly they just hit the read-only endpoints and make sure that they get back something vaguely reasonable. For the most part that just means validating the status code and the high-level data object returned (dictionary, list, etc). In a few cases, it checks specific fields in the returned data (for example, when doing a GET for a specific session template, it makes sure that the name field in that template matches what was requested).

## Issues and Related PRs

This re-enables the tests that had been disabled as the quick fix for [CASMINST-5240](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5240).

## Testing

I tested the updates cmsdev tool on fanta. All of the tests pass except for the BOS v2 healthz check, but that is due to BOS bug [CASMCMS-8163](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8163).

```text
ncn-m001:/tmp # ./usr/local/bin/cmsdev test -q bos
Starting main run, version: 1.7.0, tag: nwFJN
Starting sub-run, tag: nwFJN-bos
ERROR (run tag nwFJN-bos): GET https://api-gw-service-nmn.local/apis/bos/v2/healthz: expected status code 200, got 500
ERROR (run tag nwFJN-bos): CLI command failed (and does not look like a CLI config issue) (bos v2 healthz list --format json)
ERROR (run tag nwFJN-bos): CLI command failed (and does not look like a CLI config issue) (bos healthz list --format json)
Ended sub-run, tag: nwFJN-bos (duration: 27.16132243s)
Ended run, tag: nwFJN (duration: 27.172237249s)
FAILURE
```

## Risks and Mitigations

I think the risk of missing bugs is higher than the risk of improving this test. For example, [CASMCMS-8163](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8163) would have been identified much sooner had these improvements been already in place.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
