### PR TITLE
CASMCMS-8193: cmsdev: Default CLI BOS version back to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Modify BOS tests to reflect change of default CLI version back to v1.
+
 ## [1.7.0] - 2022-08-22
 
 ### Added

--- a/cmsdev/internal/test/bos/bos_components.go
+++ b/cmsdev/internal/test/bos/bos_components.go
@@ -39,7 +39,6 @@ import (
 const bosV2ComponentsUri = bosV2BaseUri + "/components"
 
 const bosV2ComponentsCLI = "components"
-const bosDefaultComponentsCLI = bosV2ComponentsCLI
 
 // The componentsTestsURI and componentsTestsCLICommand functions define the API and CLI versions of the BOS components subtests.
 // They both do the same thing:
@@ -64,11 +63,6 @@ func componentsTestsCLI() (passed bool) {
 
 	// v2
 	if !componentsTestsCLICommand("v2", bosV2ComponentsCLI) {
-		passed = false
-	}
-
-	// default (v2)
-	if !componentsTestsCLICommand(bosDefaultComponentsCLI) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_healthz.go
+++ b/cmsdev/internal/test/bos/bos_healthz.go
@@ -39,7 +39,7 @@ const bosV2HealthzUri = bosV2BaseUri + "/healthz"
 
 const bosV1HealthzCLI = "healthz"
 const bosV2HealthzCLI = "healthz"
-const bosDefaultHealthzCLI = bosV2HealthzCLI
+const bosDefaultHealthzCLI = bosV1HealthzCLI
 
 func healthzTestsAPI(params *common.Params) (passed bool) {
 	passed = true

--- a/cmsdev/internal/test/bos/bos_options.go
+++ b/cmsdev/internal/test/bos/bos_options.go
@@ -38,7 +38,6 @@ import (
 const bosV2OptionsUri = bosV2BaseUri + "/options"
 
 const bosV2OptionsCLI = "options"
-const bosDefaultOptionsCLI = bosV2OptionsCLI
 
 func optionsTestsAPI(params *common.Params) (passed bool) {
 	passed = true
@@ -59,11 +58,6 @@ func optionsTestsCLI() (passed bool) {
 
 	// "v2 options list"
 	if !basicCLIListVerifyStringMapTest("v2", bosV2OptionsCLI) {
-		passed = false
-	}
-
-	// "options list"
-	if !basicCLIListVerifyStringMapTest(bosDefaultOptionsCLI) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_session.go
+++ b/cmsdev/internal/test/bos/bos_session.go
@@ -40,7 +40,7 @@ const bosV2SessionsUri = bosV2BaseUri + "/sessions"
 
 const bosV1SessionsCLI = "session"
 const bosV2SessionsCLI = "sessions"
-const bosDefaultSessionsCLI = bosV2SessionsCLI
+const bosDefaultSessionsCLI = bosV1SessionsCLI
 
 // The sessionsV1TestsURI, sessionsV2TestsURI, sessionsV1TestsCLICommand, and sessionsV2TestsCLICommand functions define the API and CLI versions of the
 // BOS v1 and v2 session subtests.
@@ -50,7 +50,8 @@ const bosDefaultSessionsCLI = bosV2SessionsCLI
 //    whereas for v2 this should be a list of dictionary objects)
 // 3. If the list returned is empty, then the subtest is over. Otherwise, select the first element of the list. (If bosV2, extract the "name" field of that element).
 // 4. Do a GET/describe on that particular session
-// 5. Verify that this succeeds and returns something of the right general form, which has the expected session ID (v1) or name (v2)
+// 5. Verify that this succeeds and returns something of the right general form. For BOS v2, also verify that it has the expected name
+//    (in v1, the session ID is not in the returned object)
 
 func sessionsTestsAPI(params *common.Params) (passed bool) {
 	passed = true
@@ -81,8 +82,8 @@ func sessionsTestsCLI() (passed bool) {
 		passed = false
 	}
 
-	// default (v2) sessions
-	if !sessionsV2TestsCLICommand(bosDefaultSessionsCLI) {
+	// default (v1) sessions
+	if !sessionsV1TestsCLICommand(bosDefaultSessionsCLI) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_sessiontemplate.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate.go
@@ -43,11 +43,11 @@ const bosV2SessionTemplateTemplateUri = bosV2BaseUri + "/sessiontemplatetemplate
 
 const bosV1SessionTemplatesCLI = "sessiontemplate"
 const bosV2SessionTemplatesCLI = "sessiontemplates"
-const bosDefaultSessionTemplatesCLI = bosV2SessionTemplatesCLI
+const bosDefaultSessionTemplatesCLI = bosV1SessionTemplatesCLI
 
 const bosV1SessionTemplateTemplateCLI = "sessiontemplatetemplate"
 const bosV2SessionTemplateTemplateCLI = "sessiontemplatetemplate"
-const bosDefaultSessionTemplateTemplateCLI = bosV2SessionTemplateTemplateCLI
+const bosDefaultSessionTemplateTemplateCLI = bosV1SessionTemplateTemplateCLI
 
 // The sessionTemplatesTestsURI and sessionTemplatesTestsCLICommand functions define the API and CLI versions of the BOS session template subtests.
 // They both do the same thing:

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -43,7 +43,7 @@ const bosV2VersionUri = bosV2BaseUri + "/version"
 
 const bosV1VersionCLI = "version"
 const bosV2VersionCLI = "version"
-const bosDefaultVersionCLI = bosV2VersionCLI
+const bosDefaultVersionCLI = bosV1VersionCLI
 
 func versionTestsAPI(params *common.Params) (passed bool) {
 	passed = true


### PR DESCRIPTION
## Summary and Scope

This modifies the cmsdev BOS tests as follows:
- For the things exclusive to BOS v2 (options, components), remove the corresponding CLI tests where the BOS version is not specified (with v1 as the default, they won't work without the version specified)
- For the things which exist in both BOS versions, update the BOS tests so that when calling the CLI without the version, it uses the correct v1 command format (session vs sessions, sessiontemplate vs sessiontemplates) and, in the cases where they differ (just sessions), calls the appropriate version of the test function.

## Issues and Related PRs

- Resolves [CASMCMS-8193](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8193)
- Related to the corresponding CLI change implemented with [CASMCMS-8192](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8192)
  - PR: https://github.com/Cray-HPE/craycli/pull/59

## Testing

I ran it on a csm-1.2 system and verified that everything passed except for the v2 API and CLI tests (since v2 did not exist on the system). This verifies that the default CLI tests were correctly switched over the v1 versions.

On surtur, the csm-1.3 build is old enough that the default CLI version had not yet been changed to v2. I ran the tests there and the only failure was the v2 healthz issue (because the fix for that was not on the system).

## Risks and Mitigations

Without this, if we revert the CLI default BOS version, the cmsdev tests will fail.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
