### PR TITLE
CASMCMS-8203: cmsdev: Do not dereference null points in VCS test error paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Spelling corrections.
+- Removed two lines that dereferenced null error pointers in VCS test error paths.
 
 ## [1.8.0] - 2022-08-24
 

--- a/cmsdev/internal/test/vcs/vcs_repo.go
+++ b/cmsdev/internal/test/vcs/vcs_repo.go
@@ -312,7 +312,6 @@ func runCmd(shouldPass bool, cmdName string, cmdArgs ...string) bool {
 		return false
 	} else if cmdResult.Rc != 0 {
 		if !cmdResult.Ran || shouldPass {
-			common.Error(err)
 			common.Errorf("Command failed")
 			return false
 		} else {
@@ -360,7 +359,6 @@ func runGitCmd(shouldPass bool, cmdArgs ...string) bool {
 			common.Infof("Important: This means the overall test will fail even if this command works on retry!")
 			tryInsecure = true
 		} else {
-			common.Error(err)
 			common.Errorf("Command failed")
 			return false
 		}


### PR DESCRIPTION
## Summary and Scope

While looking into a Gitea problem on starlord I stumbled across a case where the cmsdev VCS test tries to dereference a null pointer and has an ugly crash. This is in the error path of the test, and isn't the cause of the test failure. But it does cause the cmsdev suite to crash instead of running the rest of its tests. 

After I identified the problem, I spotted one other place where it existed in the code. This PR corrects both. The fix is very simple -- delete the two lines of code which are using the null pointer. They were accidentally cut and pasted from other locations and were never meant to be there.

## Issues and Related PRs

This resolves [CASMCMS-8203](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8203).
This was found during debug of [CASMTRIAGE-4074](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4074).

## Testing

I tested this on starlord. The test still fails (as it should), but without all the dramatics.

```text
ncn-m001:/tmp/q # ./usr/local/bin/cmsdev test -q vcs
Starting main run, version: 1.9.0, tag: X4nKd
Starting sub-run, tag: X4nKd-vcs
ERROR (run tag X4nKd-vcs): Command failed
Ended sub-run, tag: X4nKd-vcs (duration: 3.02428231s)
Ended run, tag: X4nKd (duration: 3.035709091s)
FAILURE
```

## Risks and Mitigations

Extremely low risk. The two removed lines are both in error paths and both were only there to print error messages (which were already being properly printed by the lines that remain).

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
