### PR TITLE
CASMCMS-8210: cmsdev: Add CLI tests for bos list, bos v1 list, and bos v2 list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- cmsdev: Add testing of 3 BOS CLI commands: "bos list", "bos v1 list", and "bos v2 list".
+
 ## [1.8.1] - 2022-09-06
 
 ### Changed

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -86,18 +86,33 @@ func versionTestsCLI() (passed bool) {
 
 	// Make sure that "version list" CLI command succeeds and returns a dictionary object.
 
-	// v1 version list
+	// /v1 endpoint - "cray bos v1 list"
+	if !basicCLIListVerifyStringMapTest("v1") {
+		passed = false
+	}
+
+	// v1 version list - "cray bos v1 version list"
 	if !basicCLIListVerifyStringMapTest("v1", bosV1VersionCLI) {
 		passed = false
 	}
 
-	// v2 version list
+	// /v2 endpoint - "cray bos v2 list"
+	if !basicCLIListVerifyStringMapTest("v2") {
+		passed = false
+	}
+
+	// v2 version list - "cray bos v2 version list"
 	if !basicCLIListVerifyStringMapTest("v2", bosV2VersionCLI) {
 		passed = false
 	}
 
-	// version list
+	// version list - "cray bos version list"
 	if !basicCLIListVerifyStringMapTest(bosDefaultVersionCLI) {
+		passed = false
+	}
+
+	// default endpoint - "cray bos list"
+	if !basicCLIListVerifyStringMapTest() {
 		passed = false
 	}
 


### PR DESCRIPTION
## Summary and Scope

I noticed that there were 3 BOS CLI commands not being covered by cmsdev. This PR adds very basic tests of them (just making sure they return dictionary objects). The added commands are:
- `cray bos list`
- `cray bos v1 list`
- `cray bos v2 list`

## Testing

I ran the updated test on surtur and verified that all 3 new tests were executed successfully.

Relevant excerpt:

```text
...
Testing BOS CLI (v1 list)
Testing BOS CLI (v1 version list)
Testing BOS CLI (v2 list)
Testing BOS CLI (v2 version list)
Testing BOS CLI (version list)
Testing BOS CLI (list)
Testing BOS CLI (v1 healthz list)
...
```

## Risks and Mitigations

Low risk. The new tests are very basic, and re-use existing generic CLI test functions (since we are just making sure that we get a dictionary back). Because of this, the chance of introducing a new test error is low.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
