### PR TITLE
CASMCMS-8473: Do not run tftp file transfer test from master NCNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - cmsdev: Cosmetic changes made to appease latest gofmt version
+- cmsdev: Do not run tftp file transfer test from master NCNs
 
 ## [1.11.0] - 2023-01-30
 
 ### Removed
 
-- cmsdev: Removed CRUS component, to reflect its removal in CSM 1.6.
+- cmsdev: Removed CRUS component, to reflect its removal in CSM 1.5.
 
 ## [1.10.1] - 2022-12-20
 

--- a/cmsdev/internal/lib/common/helpers.go
+++ b/cmsdev/internal/lib/common/helpers.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,9 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
+	"regexp"
 )
 
 func DecodeJSONIntoStringMap(mapJsonBytes []byte) (map[string]interface{}, error) {
@@ -154,5 +156,20 @@ func ValidateStringFieldValue(objectName, fieldName, expectedFieldValue string, 
 		return
 	}
 	Debugf("%s has expected value for \"%s\" field", objectName, fieldName)
+	return
+}
+
+func RunningOnMaster() (isMaster bool, err error) {
+	// Checks the hostname of the node where cmsdev is running.
+	// Returns true if name begins with ncn-m###
+	// Returns false otherwise
+	var hostname string
+
+	hostname, err = os.Hostname()
+	if err != nil {
+		return
+	}
+	Debugf("Hostname is '%s'", hostname)
+	isMaster, _ = regexp.MatchString("^ncn-m[0-9]{3}.*$", hostname)
 	return
 }


### PR DESCRIPTION
## Summary and Scope

The cmsdev tftp file transfer subtest fails when run from master NCNs, now that the modprobe pods do not run on master nodes. I discussed this with Jeanne. This is not a problem beyond the fact that the test fails. This PR modifies cmsdev so that that particular subtest will not run when cmsdev is run on master NCNs.

## Issues and Related PRs

- Resolves [CASMCMS-8473](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8473)
- Problem created by the change made in [CASMCMS-8450](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8450)
- Problem reported by [CASMTRIAGE-5071](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5071)

I will have an additional PR to add a Goss test which runs the cmsdev tftp test on a worker NCN, so we do not lose this test coverage. I will also update the CSM health check docs to note this. These PRs are not ready yet (but they do not need to be ready before this one goes into the build)

## Testing

I tested this on drax and starlord, the two systems which encountered the problem. With the updated cmsdev, it skipped the tftp file transfer test when running on master NCNs, but still ran it when running on workers. All other tests continued to run and pass as before.

Output snippet on master NCN:
```test
Trying to run test command in ipxe container
Trying to list /shared_tftp/ipxe.efi file in ipxe container
Trying to generate md5sum of /shared_tftp/ipxe.efi file in ipxe container
tftp file transfer test cannot run on master NCNs -- skipping
```

Worker NCN:
```text
Trying to run test command in ipxe container
Trying to list /shared_tftp/ipxe.efi file in ipxe container
Trying to generate md5sum of /shared_tftp/ipxe.efi file in ipxe container
Looking up k8s service cray-tftp in namespace services
Service cray-tftp, namespace services, cluster IP = 10.25.21.6
Service cray-tftp, namespace services, external IP = 10.92.100.60
Service cray-tftp, namespace services, port = 69
Testing tftp file transfer from cluster IP:port (10.25.21.6:69)
Initializing tftp client for 10.25.21.6:69
```

## Risks and Mitigations

Low risk -- changes are very limited, and only consist of excluding one subtest when run on master NCNs. And without this, this subtest will always fail on master NCNs.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
