### PR TITLE
CASMCMS-8479: cmsdev: Fix null pointer exception when run before CSM is deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Fixed null pointer exception when run before CSM is deployed.
+
 ## [1.11.1] - 2023-03-16
 
 ### Changed

--- a/cmsdev/internal/lib/cms/cms.go
+++ b/cmsdev/internal/lib/cms/cms.go
@@ -56,14 +56,14 @@ func loadCMSServiceData() {
 		case "bos":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["bos"])
 			if len(podNames) != 0 {
+				pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["bosPvc"])
 				cmsServiceData["bos"] = &serviceData{
 					serviceAPIName:       podNames[0],
 					serviceContainerName: "cray-bos",
 					podNames:             podNames,
+					pvcNames:             pvcNames,
 				}
 			}
-			pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["bosPvc"])
-			cmsServiceData["bos"].pvcNames = pvcNames
 		case "cfs":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["cfsServices"])
 			if len(podNames) != 0 {
@@ -81,23 +81,23 @@ func loadCMSServiceData() {
 		case "conman":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["conman"])
 			if len(podNames) != 0 {
+				pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["conmanPvc"])
 				cmsServiceData["conman"] = &serviceData{
 					serviceAPIName: podNames[0],
 					podNames:       podNames,
+					pvcNames:       pvcNames,
 				}
 			}
-			pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["conmanPvc"])
-			cmsServiceData["conman"].pvcNames = pvcNames
 		case "ims":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["ims"])
 			if len(podNames) != 0 {
+				pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["imsPvc"])
 				cmsServiceData["ims"] = &serviceData{
 					serviceAPIName: podNames[0],
 					podNames:       podNames,
+					pvcNames:       pvcNames,
 				}
 			}
-			pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["imsPvc"])
-			cmsServiceData["ims"].pvcNames = pvcNames
 		case "ipxe":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["ipxe"])
 			if len(podNames) != 0 {
@@ -109,23 +109,23 @@ func loadCMSServiceData() {
 		case "tftp":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["tftp"])
 			if len(podNames) != 0 {
+				pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["tftpPvc"])
 				cmsServiceData["tftp"] = &serviceData{
 					serviceAPIName: podNames[0],
 					podNames:       podNames,
+					pvcNames:       pvcNames,
 				}
 			}
-			pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["tftpPvc"])
-			cmsServiceData["tftp"].pvcNames = pvcNames
 		case "vcs":
 			podNames, _ := k8s.GetPodNames(common.NAMESPACE, common.PodServiceNamePrefixes["vcs"])
 			if len(podNames) != 0 {
+				pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["vcs"])
 				cmsServiceData["vcs"] = &serviceData{
 					serviceAPIName: podNames[0],
 					podNames:       podNames,
+					pvcNames:       pvcNames,
 				}
 			}
-			pvcNames, _ := k8s.GetPVCNames(common.NAMESPACE, common.PodServiceNamePrefixes["vcs"])
-			cmsServiceData["tftp"].pvcNames = pvcNames
 		}
 	}
 }


### PR DESCRIPTION
## Summary and Scope

As part of adding the cmsdev test tool to Goss, Mikhail noticed that if he ran it before CSM was deployed, it hit a null pointer exception. While the tool is not intended to be useful before CSM is deployed, it still doesn't need to be failing in such an ugly way. The cause is actually a fairly basic logic problem where a data structure wasn't initialized (because the services aren't running), but then later it tries to update a field in that data structure.

There are actually a few instances of this in the same function.

This PR rearranges things so that any attempt to write to the data structure happens in a context when it is initialized (mostly this just involved moving some of the code inside of an earlier conditional).

## Testing

I don't have a system handy where I can reproduce the original problem, but I did test by forcing the code to go down that path and verify that the fixed version avoids the problem. I also verified that everything still works on the good path just as it did before these changes.

On a system where none of the services are deployed, now the tool should just give no output when asked to list the services, rather than hit the null pointer exception.

## Risks and Mitigations

Low risk -- the failure path is only hit in cases where CSM is not deployed.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
