### PR TITLE
CASMCMS-8480: cmsdev: Add option to list possible tests to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- cmsdev: Add -l option to "tests" to list possible tests to run. --exclude-alises may be specified
+  to exclude aliases from this listing.
+
 ### Changed
 
 - cmsdev: Fixed null pointer exception when run before CSM is deployed.

--- a/cmsdev/internal/cmd/test.go
+++ b/cmsdev/internal/cmd/test.go
@@ -156,6 +156,10 @@ var testCmd = &cobra.Command{
 	Long: `test command runs service tests.
 Example Commands:
 
+cmsdev test -l
+  # list all valid services to test
+cmsdev test -l --exclude-aliases
+  # list all valid services to test, excluding aliases
 cmsdev test conman
   # runs conman tests
 cmsdev test tftp --no-log -q
@@ -163,25 +167,52 @@ cmsdev test tftp --no-log -q
 cmsdev test cfs -r --verbose
   # runs cfs tests with verbosity and retry on failure`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: add custom flag validation
-		if len(args) < 1 {
-			common.Usagef("argument required, provide 'all' or at least one cms service name: %s\n", strings.Join(common.CMSServices, " "))
-		}
-
-		// TODO: pass these flags as args in a more elegant way
 		noLogs, _ := cmd.Flags().GetBool("no-log")
 		logsDir, _ := cmd.Flags().GetString("log-dir")
 		retry, _ := cmd.Flags().GetBool("retry")
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		verbose, _ := cmd.Flags().GetBool("verbose")
+		listTests, _ := cmd.Flags().GetBool("list")
+		excludeAliases, _ := cmd.Flags().GetBool("exclude-aliases")
 
 		if quiet && verbose {
 			common.Usagef("--quiet and --verbose are mutually exclusive")
 		}
 
 		var s string
-		allServices := false
 		services := make([]string, 0)
+
+		if listTests {
+			// --list was passed
+			if noLogs || logsDir != "" || retry || quiet || verbose {
+				common.Usagef("--no-log, --log-dir, --retry, --quiet, and --verbose are not valid with --list")
+			} else if len(args) > 0 {
+				common.Usagef("Invalid arguments specified with --list: %s", strings.Join(args, " "))
+			}
+			if !excludeAliases {
+				// Start with the "all" alias
+				services = append(services, "all")
+			}
+			// Append the remaining services (omitting aliases if specified)
+			for _, s = range common.CMSServices {
+				if excludeAliases && common.StringInArray(s, common.CMSServicesDuplicates) {
+					// Skip this one, as it is an alias of another one
+					continue
+				}
+				services = append(services, s)
+			}
+			common.Infof(strings.Join(services, " "))
+			return
+		}
+
+		// --list was not passed
+		if excludeAliases {
+			common.Usagef("--exclude-aliases is only valid with --list")
+		} else if len(args) < 1 {
+			common.Usagef("argument required, provide 'all' or at least one cms service name: %s\n", strings.Join(common.CMSServices, " "))
+		}
+
+		allServices := false
 		for _, a := range args {
 			s = strings.TrimSpace(a)
 			// do some command line args checking
@@ -256,4 +287,6 @@ func init() {
 	testCmd.Flags().BoolP("retry", "r", false, "retry on failure")
 	testCmd.Flags().BoolP("quiet", "q", false, "quiet mode")
 	testCmd.Flags().BoolP("verbose", "v", false, "verbose mode")
+	testCmd.Flags().BoolP("list", "l", false, "list valid service tests")
+	testCmd.Flags().BoolP("exclude-aliases", "", false, "exclude aliases from list of valid service tests")
 }


### PR DESCRIPTION
## Summary and Scope

@mtupitsyn  requested a way to have cmsdev list all of the possible tests it can run. Currently it does provide that information in usage messages, but there isn't a proper way to just query it for the information. This ticket adds a "--list" or "-l" argument that can be used with "cmsdev test". It will print a list of all valid tests that cmsdev can run (on a single line, separated by whitespace).

The "--exclude-aliases" option is also added, which doesn't include aliases in this output. For example, it would omit "all" (which is an alias to run all of the tests) and "gitea" (which is an alias for the "vcs" test).

These changes are all made to the section of cmsdev which does argument parsing, before any tests are run. It should have no impact on the normal usage of the tool to run tests, since the new option is mutually exclusive with all of the test running options.

## Testing

I tested this on wasp and verified that it does the right thing for --list both with and without the --exclude-aliases argument.

```text
ncn-m001:~/mitch2 # ./usr/local/bin/cmsdev test -l
all bos cfs conman gitea ims ipxe tftp vcs
ncn-m001:~/mitch2 # echo $?
0
ncn-m001:~/mitch2 # ./usr/local/bin/cmsdev test -l --exclude-aliases
bos cfs conman ims tftp vcs
ncn-m001:~/mitch2 # echo $?
0
```

I also verified that running the tests normally still works as usual.

## Risks and Mitigations

Low risk -- I tested the new options thoroughly, and when running without the new options, nothing has changed.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
