### PR TITLE
CASMCMS-8495: cmsdev: Update default CLI BOS version to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Update default CLI BOS version to v2
+
 ## [1.11.4] - 2023-03-27
 
 ### Removed

--- a/cmsdev/internal/test/bos/bos_components.go
+++ b/cmsdev/internal/test/bos/bos_components.go
@@ -37,6 +37,7 @@ import (
 const bosV2ComponentsUri = bosV2BaseUri + "/components"
 
 const bosV2ComponentsCLI = "components"
+const bosDefaultComponentsCLI = bosV2ComponentsCLI
 
 // The componentsTestsURI and componentsTestsCLICommand functions define the API and CLI versions of the BOS components subtests.
 // They both do the same thing:
@@ -61,6 +62,11 @@ func componentsTestsCLI() (passed bool) {
 
 	// v2
 	if !componentsTestsCLICommand("v2", bosV2ComponentsCLI) {
+		passed = false
+	}
+
+	// default (v2)
+	if !componentsTestsCLICommand(bosDefaultComponentsCLI) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_healthz.go
+++ b/cmsdev/internal/test/bos/bos_healthz.go
@@ -37,7 +37,7 @@ const bosV2HealthzUri = bosV2BaseUri + "/healthz"
 
 const bosV1HealthzCLI = "healthz"
 const bosV2HealthzCLI = "healthz"
-const bosDefaultHealthzCLI = bosV1HealthzCLI
+const bosDefaultHealthzCLI = bosV2HealthzCLI
 
 func healthzTestsAPI(params *common.Params) (passed bool) {
 	passed = true

--- a/cmsdev/internal/test/bos/bos_options.go
+++ b/cmsdev/internal/test/bos/bos_options.go
@@ -36,6 +36,7 @@ import (
 const bosV2OptionsUri = bosV2BaseUri + "/options"
 
 const bosV2OptionsCLI = "options"
+const bosDefaultOptionsCLI = bosV2OptionsCLI
 
 func optionsTestsAPI(params *common.Params) (passed bool) {
 	passed = true
@@ -56,6 +57,11 @@ func optionsTestsCLI() (passed bool) {
 
 	// "v2 options list"
 	if !basicCLIListVerifyStringMapTest("v2", bosV2OptionsCLI) {
+		passed = false
+	}
+
+	// "options list"
+	if !basicCLIListVerifyStringMapTest(bosDefaultOptionsCLI) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_session.go
+++ b/cmsdev/internal/test/bos/bos_session.go
@@ -38,7 +38,7 @@ const bosV2SessionsUri = bosV2BaseUri + "/sessions"
 
 const bosV1SessionsCLI = "session"
 const bosV2SessionsCLI = "sessions"
-const bosDefaultSessionsCLI = bosV1SessionsCLI
+const bosDefaultSessionsCLI = bosV2SessionsCLI
 
 // The sessionsV1TestsURI, sessionsV2TestsURI, sessionsV1TestsCLICommand, and sessionsV2TestsCLICommand functions define the API and CLI versions of the
 // BOS v1 and v2 session subtests.
@@ -80,8 +80,8 @@ func sessionsTestsCLI() (passed bool) {
 		passed = false
 	}
 
-	// default (v1) sessions
-	if !sessionsV1TestsCLICommand(bosDefaultSessionsCLI) {
+	// default (v2) sessions
+	if !sessionsV2TestsCLICommand(bosDefaultSessionsCLI) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_sessiontemplate.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate.go
@@ -41,11 +41,11 @@ const bosV2SessionTemplateTemplateUri = bosV2BaseUri + "/sessiontemplatetemplate
 
 const bosV1SessionTemplatesCLI = "sessiontemplate"
 const bosV2SessionTemplatesCLI = "sessiontemplates"
-const bosDefaultSessionTemplatesCLI = bosV1SessionTemplatesCLI
+const bosDefaultSessionTemplatesCLI = bosV2SessionTemplatesCLI
 
 const bosV1SessionTemplateTemplateCLI = "sessiontemplatetemplate"
 const bosV2SessionTemplateTemplateCLI = "sessiontemplatetemplate"
-const bosDefaultSessionTemplateTemplateCLI = bosV1SessionTemplateTemplateCLI
+const bosDefaultSessionTemplateTemplateCLI = bosV2SessionTemplateTemplateCLI
 
 // The sessionTemplatesTestsURI and sessionTemplatesTestsCLICommand functions define the API and CLI versions of the BOS session template subtests.
 // They both do the same thing:

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -41,7 +41,7 @@ const bosV2VersionUri = bosV2BaseUri + "/version"
 
 const bosV1VersionCLI = "version"
 const bosV2VersionCLI = "version"
-const bosDefaultVersionCLI = bosV1VersionCLI
+const bosDefaultVersionCLI = bosV2VersionCLI
 
 func versionTestsAPI(params *common.Params) (passed bool) {
 	passed = true


### PR DESCRIPTION
## Summary and Scope

[CASMCMS-8481](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8481) changed the default BOS version in the Cray CLI from v1 to v2. However, it did not update the corresponding cmsdev BOS test. This caused the test to fail when it tried to run the CLI commands without specifying a version, because the syntax of the sessions/sessiontemplates commands changes from v1 to v2.

This isn't the first time we changed the BOS CLI default in CSM, and had to make a corresponding change to cmsdev. In fact, it's not even the first time we changed the default to be BOS v2. The last time, we ended up changing it back, because we needed to give advance notice to customers before doing it. But before that decision had been made, the cmsdev test tool had been updated. All of this is just to say that this current PR is essentially just reverting a previous PR.

This PR updates the test tool so that it knows the CLI default for BOS is v2. This has a few practical impacts:
1) The correct command syntax is used when no version is specified (this will fix the specific test failures reported because of the version change)
2) Some BOS CLI command paths now exist that did not before, because there are some new commands in BOS v2, and now they are also available using the CLI if the version is not specified. With this PR, the test tool will also include those in its testing.

## Issues and Related PRs

- Test failures caused by [CASMCMS-8481](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8481)
- Resolves [CASMCMS-8495](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8495)

## Testing

I tested the updated cmsdev tool on fanta, where the test failures were reported. I validated that:
1) The failures no longer occur
2) All expected CLI tests are executed (including those changed as described earlier)

In addition, as I mentioned before, the change being made in this PR was actually in CSM builds for a while back when the default version was briefly set to BOS v2. So it got tested at that time as well, not only by me but on live installs.

## Risks and Mitigations

Without this change, the cmsdev test will fail for bos every time it is run on CSM 1.4+.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
