### PR TITLE
CASMCMS-8498: cmsdev: Fix typo in message; add namespace info to some messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Fixed typo in Kubernetes pod check function.
+- cmsdev: Added namespace detail to output of some Kubernetes check functions.
+
 ## [1.11.5] - 2023-03-30
 
 ### Changed

--- a/cmsdev/internal/lib/test/test.go
+++ b/cmsdev/internal/lib/test/test.go
@@ -53,19 +53,19 @@ func GetPodNamesInNamespace(namespace, serviceName string, minExpectedCount, max
 		return
 	} else if minExpectedCount == maxExpectedCount {
 		if len(podNames) != minExpectedCount {
-			common.Errorf("Expected exactly %d pod pods but found %d: %s",
-				minExpectedCount, len(podNames), strings.Join(podNames, ", "),
+			common.Errorf("Expected exactly %d %s pods in %s namespace but found %d: %s",
+				minExpectedCount, serviceName, namespace, len(podNames), strings.Join(podNames, ", "),
 			)
 		} else {
 			passed = true
 		}
 	} else if len(podNames) < minExpectedCount {
-		common.Errorf("Expected at least %d pod pods but found %d: %s",
-			minExpectedCount, len(podNames), strings.Join(podNames, ", "),
+		common.Errorf("Expected at least %d %s pods in %s namespace but found %d: %s",
+			minExpectedCount, serviceName, namespace, len(podNames), strings.Join(podNames, ", "),
 		)
 	} else if maxExpectedCount > 0 && len(podNames) > maxExpectedCount {
-		common.Errorf("Expected at most %d pod pods but found %d: %s",
-			maxExpectedCount, len(podNames), strings.Join(podNames, ", "),
+		common.Errorf("Expected at most %d %s pods in %s namespace but found %d: %s",
+			maxExpectedCount, serviceName, namespace, len(podNames), strings.Join(podNames, ", "),
 		)
 	} else {
 		passed = true
@@ -86,7 +86,7 @@ func CheckPodStatsInNamespace(namespace, podName string, params ...string) (pass
 	passed = true
 
 	// get pod and container status details
-	common.Infof("checking pod status for %s expecting %s", podName, "Running")
+	common.Infof("checking pod status for %s in %s namespace; expecting Running", podName, namespace)
 	stats, err = k8s.GetPodStats(namespace, podName)
 	if err != nil {
 		common.Error(err)
@@ -155,7 +155,7 @@ func CheckPodStats(podName string, params ...string) bool {
 // Returns true if no errors, false otherwise
 func CheckPVCStatusInNamespace(namespace, pvcName string) (passed bool) {
 	passed = false
-	common.Infof("checking pvc status for %s expecting %s", pvcName, "Bound")
+	common.Infof("checking pvc status for %s in namespace %s; expecting Bound", pvcName, namespace)
 	status, err := k8s.GetPVCStatus(namespace, pvcName)
 	if err == nil {
 		if len(status) == 0 {


### PR DESCRIPTION
## Summary and Scope

I noticed in a recent ticket the following message in a cmsdev test log:

```text
ERROR (run tag 04xIh-conman): Expected at least 2 pod pods but found 1: cray-console-node-0
```

This probably was meant to say `2 cray-console-node pods` not `2 pod pods`.

This PR fixes that. In addition, I noticed some of the Kubernetes check messages don't include the namespace, but probably should. So this PR changes that as well.

Finally, I found a couple of cases where string formatting was being used unnecessarily (%s with a literal string parameter), so I simplified those.

No test behavior is changed, just the messages.

## Issues and Related PRs

- I discovered the typo while debugging [CASMTRIAGE-5139](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5139).
- Resolves [CASMCMS-8498](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8498)

## Testing

On wasp I scaled console-node down to 1 and ran the test, verifying that the error messages now look as they should:

```text
ERROR (run tag 7Om0X-conman): Expected at least 2 cray-console-node pods in services namespace but found 1: cray-console-node-0
```

I also saw that the other modified messages look as they should. For example:

```text
checking pvc status for pgdata-cray-console-data-postgres-0 in namespace services; expecting Bound
```

## Risks and Mitigations

Low risk -- the changes are just to messages, and are pretty limited.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
