### PR TITLE
CASMCMS-8496: cmsdev: Stop redundant output/logging of KUBECONFIG env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Limit redundant logging and output related to KUBECONFIG environment variable
+
 ## [1.11.7] - 2023-04-04
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Currently the `cmsdev` test logs (and output, if run in verbose mode) contain a LOT of duplicate lines about the contents of the `KUBECONFIG` environment variable. This is because the `cmsdev` Kubernetes code initializes the Kubernetes configuration every time the Kubernetes API is used, and this in turn looks up the value of that environment variable. However, the K8s configuration really only needs to be initialized once per `cmsdev` execution. This PR makes that change, which will prevent with duplicate output/log messages, and also presumably will offer a (very small) performance benefit.

## Issues and Related PRs

- Resolves [CASMCMS-8496](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8496)

## Testing

I tested on wasp and verified that the duplicate output is no longer created, and that all tests continue to work as before. When running all service tests, this resulted in around 150 fewer lines of output, and was a couple of seconds faster.

## Risks and Mitigations

Low risk. If this PR broke something, it should have been apparent in my testing, since it uses the changed code extensively.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
