### PR TITLE
CASMCMS-8513: cmsdev: Update VCS test to reflect change to logical DB backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Update VCS test to reflect change to logical DB backups in CSM 1.5
+
 ## [1.11.7] - 2023-04-04
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

Starting in CSM 1.5, the VCS database backup job will have a different name, with the switch over to logical DB backups. This PR informs the cmsdev test tool of this change, so that it won't panic at the absence of the backup job.

## Issues and Related PRs

- Resolves [CASMCMS-8513](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8513)
- [CASMCMS-8457](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8457) originally made the change to VCS to enable the new style of backups. Ideally that Jira should also have updated the test, or opened a new ticket to do it.
- Bug discovered by [CASMTRIAGE-5130](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5130)
- VCS itself currently has a bug preventing it from doing its new logical DB backups. That is being addressed with [CASMCMS-8512](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8512).

## Testing

I applied the VCS fix for [CASMCMS-8512](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8512) on yasha (a CSM 1.5 vshasta system), as well as the the cmsdev change in this PR.

Before the cmsdev fix:

```text
ncn-w002:~/mitch # /usr/local/bin/cmsdev test -q vcs
Starting main run, version: 1.11.5, tag: y89Qi
Starting sub-run, tag: y89Qi-vcs
Found 6 vcs pods: gitea-vcs-d6854c57f-d275q, gitea-vcs-postgres-0, gitea-vcs-postgres-1, gitea-vcs-postgres-2, gitea-vcs-wait-for-postgres-2-rbd2f, logical-backup-gitea-vcs-postgres-28012031-pdjtkERROR (run tag y89Qi-vcs): expected status=Running, found status=Succeeded for podName=logical-backup-gitea-vcs-postgres-28012031-pdjtk
ERROR (run tag y89Qi-vcs): Expected exactly 1 main gitea-vcs- pod but found 2
ERROR (run tag y89Qi-vcs): No kubernetes CronJob found in namespace services with name gitea-vcs-postgresql-db-backup
Ended sub-run, tag: y89Qi-vcs (duration: 2.756730258s)
Ended run, tag: y89Qi (duration: 2.766506434s)
FAILURE
```

After this cmsdev fix:
```text
ncn-w002:~/mitch # ./usr/local/bin/cmsdev test -q vcs
Starting main run, version: 1.12.0, tag: mtUqq
Starting sub-run, tag: mtUqq-vcs
Ended sub-run, tag: mtUqq-vcs (duration: 2.721517657s)
Ended run, tag: mtUqq (duration: 2.731596257s)
SUCCESS
```

## Risks and Mitigations

Low risk. And without this change, the cmsdev VCS test will fail every time.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
