### PR TITLE
CASMCMS-8514: cmsdev: Modify BOS test to handle change to Bitnami for etcd; make pod checks more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Modify BOS test to handle change to Bitnami for etcd; make pod checks more flexible
+
 ## [1.11.7] - 2023-04-04
 
 ### Changed

--- a/cmsdev/internal/test/bos/bos.go
+++ b/cmsdev/internal/test/bos/bos.go
@@ -36,22 +36,37 @@ import (
 	"strings"
 )
 
+var optionalCompletedPodNames = []string{
+	"cray-bos-wait-for-etcd-",
+	"cray-bos-bitnami-etcd-snapshotter-",
+	"cray-bos-etcd-post-install-",
+	"cray-bos-pre-upgrade-etcd-backup-",
+}
+
 func IsBOSRunning() (passed bool) {
 	passed = true
 
-	// We expect to find 4+ cray-bos pods
-	podNames, ok := test.GetPodNamesByPrefixKey("bos", 4, -1)
+	// Look for at least 3 bos pods, although we know there are more.
+	podNames, ok := test.GetPodNamesByPrefixKey("bos", 3, -1)
 	if !ok {
 		passed = false
 	}
 	common.Infof("Found %d bos pods", len(podNames))
-	// We expect the following bos pods
-	// Exactly 1 main cray-bos pod
-	// Exactly 3 cray-bos-etcd pods
-	// Optionally 1 or more cray-bos-wait-for-etcd pods
-	mainPodCount := 0
+	// The BOS pod zoo has become rather unruly. Parts of this test were
+	// passing more by accident than anything else. Given that, this
+	// section of the check has been simplified to just make sure that there
+	// are 3 etcd pods, and that any transient pods, if they exist, have succeeded.
+
+	// Check for:
+	// Exactly 3 BOS etcd pods
+	// All pods are expected to be Running except for the following, which are expected to
+	// be Succeeded if they exist:
+	// - cray-bos-wait-for-etcd
+	// - cray-bos-bitnami-etcd-snapshotter
+	// - cray-bos-etcd-post-install
+	// - cray-bos-pre-upgrade-etcd-backup
 	etcPodCount := 0
-	waitForEtcdRe := regexp.MustCompile("cray-bos-wait-for-etcd-[0-9][0-9]*-")
+	etcdRe := regexp.MustCompile("cray-bos-bitnami-etcd-[0-9]")
 	pvcNames := make([]string, 0, 3)
 	for _, podName := range podNames {
 		common.Infof("Getting pod status for %s", podName)
@@ -64,32 +79,30 @@ func IsBOSRunning() (passed bool) {
 			common.Infof("Pod %s status is %s", podName, status)
 		}
 
-		if waitForEtcdRe.MatchString(podName) {
-			if status != "" && status != "Succeeded" {
-				common.VerboseFailedf("Pod %s has status %s, but we expect it to be Succeeded", podName, status)
+		expectedStatus := "Running"
+		if etcdRe.MatchString(podName) {
+			etcPodCount += 1
+			// There should be a corresponding pvc with the same name prepended with "data-"
+			pvcName := "data-" + podName
+			common.Infof("There should be a corresponding pvc for this pod (%s) with the name '%s'", podName, pvcName)
+			pvcNames = append(pvcNames, pvcName)
+			if !test.CheckPVCStatus(pvcName) {
 				passed = false
 			}
 		} else {
-			if strings.HasPrefix(podName, "cray-bos-etcd-") {
-				etcPodCount += 1
-				// There should be a corresponding pvc with the same name
-				common.Infof("There should be a corresponding pvc with the same name as this pod (%s)", podName)
-				pvcNames = append(pvcNames, podName)
-				if !test.CheckPVCStatus(podName) {
-					passed = false
+			for _, podPrefix := range optionalCompletedPodNames {
+				if strings.HasPrefix(podName, podPrefix) {
+					// These pods, if they exist, are expected to be Succeeded
+					expectedStatus = "Succeeded"
+					break
 				}
-			} else {
-				mainPodCount += 1
-			}
-			if status != "" && status != "Running" {
-				common.VerboseFailedf("Pod %s has status %s, but we expect it to be Running", podName, status)
-				passed = false
 			}
 		}
-	}
-	if mainPodCount == 0 {
-		common.VerboseFailedf("Did not find any main cray-bos pod")
-		passed = false
+
+		if status != "" && status != expectedStatus {
+			common.VerboseFailedf("Pod %s has status %s, but we expect it to be %s", podName, status, expectedStatus)
+			passed = false
+		}
 	}
 	if etcPodCount != 3 {
 		common.VerboseFailedf("Found %d cray-bos-etcd- pod(s), but expect to find 3", etcPodCount)


### PR DESCRIPTION
## Summary and Scope

On CSM 1.5, the cmsdev BOS test fails, because of the change to Bitnami for etcd. This resulted in some pod and PVC name changes. This PR modifies the BOS test to account for these changes.

Also, in doing this I noticed that the BOS test was not hitting other errors more by happenstance than anything else. Some of the things it was trying to check were not actually true, but it was not checking them very carefully. This PR simplifies the Kubernetes pod checks for BOS, mainly just making sure that the etcd pods look good, and that all pods are either Running or (for some transient pods) Succeeded.

## Issues and Related PRs

- Resolves [CASMCMS-8514](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8514)
- Bug discovered by [CASMTRIAGE-5129](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5129)

## Testing

I tested the updated cmsdev on yasha (the CSM 1.5 vshasta system where the test failure was hit).

Without the new cmsdev:

```text
ncn-w002:~/mitch # /usr/local/bin/cmsdev test -q bos
Starting main run, version: 1.11.5, tag: f3eId
Starting sub-run, tag: f3eId-bos
ERROR (run tag f3eId-bos): Pod cray-bos-bitnami-etcd-snapshotter-28012080-fkmq9 has status Succeeded, but we expect it to be Running
ERROR (run tag f3eId-bos): persistentvolumeclaims "cray-bos-etcd-post-install-ww45t" not found
ERROR (run tag f3eId-bos): Pod cray-bos-etcd-post-install-ww45t has status Succeeded, but we expect it to be Running
ERROR (run tag f3eId-bos): Pod cray-bos-pre-upgrade-etcd-backup-9g9st has status Succeeded, but we expect it to be Running
ERROR (run tag f3eId-bos): Found 1 cray-bos-etcd- pod(s), but expect to find 3
Ended sub-run, tag: f3eId-bos (duration: 50.165576969s)
Ended run, tag: f3eId (duration: 50.175480931s)
FAILURE
```

With the new cmsdev:

```text
ncn-w002:~/mitch # ./usr/local/bin/cmsdev test -q bos
Starting main run, version: 1.12.0, tag: pzUYt
Starting sub-run, tag: pzUYt-bos
Ended sub-run, tag: pzUYt-bos (duration: 49.359712645s)
Ended run, tag: pzUYt (duration: 49.372633887s)
SUCCESS
```

## Risks and Mitigations

Low risk. Without this change the test will always fail.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
