### PR TITLE
CASMCMS-8529: cmsdev: Collect Kubernetes information by default on failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - cmsdev: Changed default log directory to `/opt/cray/tests/install/logs/cmsdev/` to be consistent with other CSM tests.
 - cmsdev: Simplified Kubernetes artifact collection functions; collect additional information
+- cmsdev: Collect Kubernetes artifacts on failure by default
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- cmsdev: Removed reference to long removed `cmslogs` tool from [`cmsdev` README file](cmsdev/README.md)
+
 ## [1.11.8] - 2023-04-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Changed default log directory to `/opt/cray/tests/install/logs/cmsdev/` to be consistent with other CSM tests.
+
 ### Removed
 
 - cmsdev: Removed reference to long removed `cmslogs` tool from [`cmsdev` README file](cmsdev/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmsdev: Changed default log directory to `/opt/cray/tests/install/logs/cmsdev/` to be consistent with other CSM tests.
 - cmsdev: Simplified Kubernetes artifact collection functions; collect additional information
 - cmsdev: Collect Kubernetes artifacts on failure by default
+- cmsdev: Compress test artifacts, if collected. If none collected, delete empty artifact directory, if cmsdev created it
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - cmsdev: Changed default log directory to `/opt/cray/tests/install/logs/cmsdev/` to be consistent with other CSM tests.
+- cmsdev: Simplified Kubernetes artifact collection functions; collect additional information
 
 ### Removed
 

--- a/cmsdev/README.md
+++ b/cmsdev/README.md
@@ -24,7 +24,7 @@ On an installed system, these are important files and directories:
 | File or Directory | Description |
 | ------------------|-------------|
 | `/usr/local/bin/cmsdev` | The man himself |
-| `/opt/cray/tests/cmsdev.log` | Detailed log file (not to be mistaken with the output from when it is run). [See an example file](examples/cmsdev.log) |
+| `/opt/cray/tests/install/logs/cmsdev/cmsdev.log` | Detailed log file (not to be mistaken with the output from when it is run). [See an example file](examples/cmsdev.log) |
 
 Noteworthy files in the repository:
 
@@ -34,23 +34,12 @@ Noteworthy files in the repository:
 | [`cmsdev/internal/test`/](internal/test/) | Every CMS component which is tested has a directory here that contains all test code |
 | [`cmsdev/internal/lib/`](internal/lib/) | Library modules shared by the tests (e.g. Kubernetes functions, test logging functions, API/CLI functions, etc) |
 
-## Example Command Usage
+## Command Usage
+
+Run the command with the `-h` flag for a usage statement.
 
 ```bash
-cmsdev test -q all
-   # runs all CMS CT tests with minimal output
-cmsdev test bos cfs
-   # runs bos and cfs tests
-cmsdev test conman -q -r
-   # runs conman tests quietly, retrying on failure
-cmsdev test ims -v --no-log
-   # runs ims tests verbosely with logging disabled
-     default=/opt/cray/tests/cmsdev.log, --output to override default
-IMS_RECIPE_NAME=uan-recipe cmsdev test ims --no-log -v
-   # same as previous, but also verifies that an IMS recipe with the specified name exists
-   # (with distro type of sles15, by default)
-IMS_RECIPE_NAME=uan-recipe IMS_RECIPE_DISTRO=centos cmsdev test ims --no-log -v
-   # same as previous, but with the distro type specified as well
+cmsdev test -h
 ```
 
 ## Contributing

--- a/cmsdev/README.md
+++ b/cmsdev/README.md
@@ -6,7 +6,7 @@ cmsdev is a test utility for CMS services. The tool executes tests for all CMS s
 
 Building requires the installation of [Golang](https://golang.org/doc/install).
 
-Be sure to copy the repo to a directory OUTSIDE of $GOPATH/src. In this example, assume we have copied it into /tmp/stash/cms-tools
+Be sure to copy the repo to a directory OUTSIDE of `$GOPATH/src`. In this example, assume we have copied it into `/tmp/stash/cms-tools`
 
 ```bash
 cd /tmp/stash/cms-tools/cmsdev
@@ -15,22 +15,24 @@ GOOS=linux GOARCH=amd64 go build -mod vendor .
 
 ### Noteworthy file/directory locations
 
-For all CMS components, the test includes a basic check for kubernetes pods. Most also include some calls to the service itself via API and CLI. These tests should absolutely be expanded, while keeping in mind that these are intended to be quick, non-destructive tests.
+For all CMS components, the test includes a basic check for Kubernetes pods. Most also include some calls to the service itself via
+API and CLI. These tests should absolutely be expanded, while keeping in mind that these are intended to be quick, non-destructive
+tests.
 
 On an installed system, these are important files and directories:
 
 | File or Directory | Description |
 | ------------------|-------------|
-| /usr/local/bin/cmsdev | The man himself |
-| /opt/cray/tests/cmsdev.log | Detailed log file (not to be mistaken with the output from when it is run). [See an example file](examples/cmsdev.log) |
+| `/usr/local/bin/cmsdev` | The man himself |
+| `/opt/cray/tests/cmsdev.log` | Detailed log file (not to be mistaken with the output from when it is run). [See an example file](examples/cmsdev.log) |
 
-Noteworthy files in the repo:
+Noteworthy files in the repository:
 
 | File or Directory | Description |
 | ------------------|-------------|
-| [cmsdev/internal/cmd/test.go](internal/cmd/test.go) | Main test driver |
-| [cmsdev/internal/test/](internal/test/) | Every CMS component which is tested has a directory here that contains all test code |
-| [cmsdev/internal/lib/](internal/lib/) | Library modules shared by the tests (e.g. kubernetes functions, test logging functions, API/CLI functions, etc) |
+| [`cmsdev/internal/cmd/test.go`](internal/cmd/test.go) | Main test driver |
+| [`cmsdev/internal/test`/](internal/test/) | Every CMS component which is tested has a directory here that contains all test code |
+| [`cmsdev/internal/lib/`](internal/lib/) | Library modules shared by the tests (e.g. Kubernetes functions, test logging functions, API/CLI functions, etc) |
 
 ## Example Command Usage
 

--- a/cmsdev/README.md
+++ b/cmsdev/README.md
@@ -23,7 +23,6 @@ On an installed system, these are important files and directories:
 | ------------------|-------------|
 | /usr/local/bin/cmsdev | The man himself |
 | /opt/cray/tests/cmsdev.log | Detailed log file (not to be mistaken with the output from when it is run). [See an example file](examples/cmsdev.log) |
-| /usr/local/bin/cmslogs | Utility to collect most of these files to help debug test failures. [See the README here](../cmslogs) for more details |
 
 Noteworthy files in the repo:
 
@@ -53,4 +52,5 @@ IMS_RECIPE_NAME=uan-recipe IMS_RECIPE_DISTRO=centos cmsdev test ims --no-log -v
 ```
 
 ## Contributing
+
 Pull requests are welcome.

--- a/cmsdev/internal/cmd/test.go
+++ b/cmsdev/internal/cmd/test.go
@@ -250,6 +250,8 @@ cmsdev test cfs -r --verbose
 			common.SetTestService(services[0])
 			ok := DoTest(services[0], retry)
 			common.UnsetTestService()
+			// Compress test artifacts, if any
+			common.CompressArtifacts()
 			if ok {
 				common.Success()
 			} else {
@@ -268,6 +270,8 @@ cmsdev test cfs -r --verbose
 			}
 			common.UnsetTestService()
 		}
+		// Compress test artifacts, if any
+		common.CompressArtifacts()
 		if len(failed) > 0 {
 			common.Failuref("%d service tests FAILED (%s), %d passed (%s)", len(failed), strings.Join(failed, ", "),
 				len(passed), strings.Join(passed, ", "))

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -107,6 +107,28 @@ var CMSServicesDuplicates = []string{
 	"ipxe",
 }
 
+// List of Kubernetes things to collect for debug in case of failure
+var kubernetesThingsToCollect = []string{
+	"nodes",
+	"namespaces",
+	"pods",
+	"pv",
+	"pvc",
+	"services",
+	"daemonsets",
+	"statefulsets",
+	"deployments",
+	"etcd",
+	"configmaps",
+	"secrets",
+	"endpoints",
+	"postgresqls",
+	"cronjobs",
+	"jobs",
+	"sealedsecrets",
+	"etcdbackups",
+}
+
 var runTags []string
 var runStartTimes []time.Time
 var artifactDirectory, artifactFilePrefix, runTag, testService string
@@ -167,66 +189,40 @@ func ArtifactCommand(label, cmdName string, cmdArgs ...string) {
 	}
 }
 
+func ArtifactGetAllThings(thing string) {
+	ArtifactCommand("k8s-get-"+thing, "kubectl", "get", thing, "-A", "-o", "wide", "--show-labels=true")
+}
+
 func ArtifactDescribeNodes() {
 	ArtifactCommand("k8s-describe-nodes", "kubectl", "describe", "nodes")
 }
 
-func ArtifactGetAllPods() {
-	ArtifactCommand("k8s-get-pods", "kubectl", "get", "pods", "-A", "-o", "wide", "--show-labels=true")
-}
-
-func ArtifactGetAllPvcs() {
-	ArtifactCommand("k8s-get-pvc", "kubectl", "get", "pvc", "-A", "-o", "wide", "--show-kind=true", "--show-labels=true")
-}
-
-func ArtifactDescribeNamespacePods(namespace string, podNames ...string) {
+func ArtifactDescribeNamespacePods(namespace string, podNames []string) {
+	Infof("Collecting information about current Kubernetes state of following '%s' namespace pods: %s",
+		namespace, strings.Join(podNames, " "))
 	for _, podName := range podNames {
 		describeLabel := "k8s-describe-pod-" + namespace + "-" + podName
 		ArtifactCommand(describeLabel, "kubectl", "describe", "pod", "-n", namespace, podName, "--show-events=true")
 		logsLabel := "k8s-logs-" + namespace + "-" + podName
-		ArtifactCommand(logsLabel, "kubectl", "logs", "-n", namespace, podName, "--all-containers=true", "--timestamps=true")
+		ArtifactCommand(logsLabel, "kubectl", "logs", "-n", namespace, podName, "--all-containers=true", "--timestamps=true", "--prefix=true")
 	}
 }
 
-func ArtifactDescribePods(podNames ...string) {
-	ArtifactDescribeNamespacePods(NAMESPACE, podNames...)
-}
-
-func ArtifactDescribeNamespacePvcs(namespace string, pvcNames ...string) {
+func ArtifactDescribeNamespacePvcs(namespace string, pvcNames []string) {
+	Infof("Collecting information about current Kubernetes state of following '%s' namespace PVCs: %s",
+		namespace, strings.Join(pvcNames, " "))
 	for _, pvcName := range pvcNames {
 		describeLabel := "k8s-describe-pvc-" + namespace + "-" + pvcName
 		ArtifactCommand(describeLabel, "kubectl", "describe", "pvc", "-n", namespace, pvcName, "--show-events=true")
 	}
 }
 
-func ArtifactDescribePvcs(pvcNames ...string) {
-	ArtifactDescribeNamespacePvcs(NAMESPACE, pvcNames...)
-}
-
-func ArtifactsPodsPvcsNamespace(namespace string, podNames, pvcNames []string) {
-	Infof("Collecting information about current kubernetes state")
-	if len(podNames) > 0 {
-		ArtifactDescribeNamespacePods(namespace, podNames...)
+func ArtifactsKubernetes() {
+	Infof("Collecting information about current Kubernetes state")
+	for _, thing := range kubernetesThingsToCollect {
+		ArtifactGetAllThings(thing)
 	}
-	if len(pvcNames) > 0 {
-		ArtifactDescribeNamespacePvcs(namespace, pvcNames...)
-	}
-	ArtifactGetAllPods()
-	ArtifactGetAllPvcs()
 	ArtifactDescribeNodes()
-}
-
-func ArtifactsPodsPvcs(podNames, pvcNames []string) {
-	ArtifactsPodsPvcsNamespace(NAMESPACE, podNames, pvcNames)
-}
-
-func ArtifactsPodsNamespace(namespace string, podNames []string) {
-	var noPvcs []string
-	ArtifactsPodsPvcsNamespace(namespace, podNames, noPvcs)
-}
-
-func ArtifactsPods(podNames []string) {
-	ArtifactsPodsNamespace(NAMESPACE, podNames)
 }
 
 // Determines index of string in slice, otherwise returns -1

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -574,8 +574,13 @@ func UnsetTestService() {
 func InitArtifacts() {
 	artifactDirectory = os.Getenv("ARTIFACTS")
 	if len(artifactDirectory) == 0 {
-		Warnf("ARTIFACTS environment variable not set; no artifacts will be saved")
-		return
+		if len(logFileDir) == 0 {
+			Warnf("ARTIFACTS environment variable not set and test logging disabled; no artifacts will be saved")
+			return
+		}
+		// Default to log_directory/timestamp
+		artifactDirectory = logFileDir + "/" + "artifacts-" + time.Now().Format(time.RFC3339Nano)
+		Debugf("ARTIFACTS environment variable not set. Defaulting to '%s'", artifactDirectory)
 	}
 	err := CreateDirectoryIfNeeded(artifactDirectory)
 	if err != nil {
@@ -594,7 +599,7 @@ func init() {
 	logFile, testLog = nil, nil
 	printInfo, printWarn, printError, printResults = true, true, true, true
 	printVerbose = false
-	runTag, artifactDirectory, artifactFilePrefix, testService = "", "", "", ""
+	runTag, artifactDirectory, artifactFilePrefix, testService, logFileDir = "", "", "", "", ""
 	// Call the init function for the printlog source file
 	printlogInit()
 }

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -36,6 +36,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -130,8 +131,11 @@ var kubernetesThingsToCollect = []string{
 }
 
 var runTags []string
+var runTag, testService string
 var runStartTimes []time.Time
-var artifactDirectory, artifactFilePrefix, runTag, testService string
+
+var artifactDirectory, artifactFilePrefix string
+var artifactDirectoryCreated, artifactsLogged bool
 
 // Set and unset the run sub-tag
 func SetRunSubTag(tag string) {
@@ -181,6 +185,7 @@ func ArtifactCommand(label, cmdName string, cmdArgs ...string) {
 		Warnf("Error starting command; %s", err.Error())
 		return
 	}
+	artifactsLogged = true
 	err = cmd.Wait()
 	if err != nil {
 		Warnf("Command failed; %s", err.Error())
@@ -531,21 +536,39 @@ func Restful(method, url string, params Params) (*resty.Response, error) {
 
 }
 
-func CreateDirectoryIfNeeded(path string) error {
+func CreateDirectoryIfNeeded(path string) (error, bool) {
+	// bool is True if we create the directory, false if it
+	// already exists.
+
 	// First see if the path already exists
 	fileInfo, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		// It does not exist, so let's create it
-		return os.MkdirAll(path, 0755)
+		return os.MkdirAll(path, 0755), true
 	} else if err != nil {
-		return err
+		return err, false
 	}
 
 	// It exists, so make sure it is a directory
 	if fileInfo.IsDir() {
-		return nil
+		return nil, false
 	}
-	return fmt.Errorf("Path exists but is not a directory: %s", path)
+	return fmt.Errorf("Path exists but is not a directory: %s", path), false
+}
+
+func RemoveEmptyDirectory(path string) error {
+	// First see if the path already exists
+	dirInfo, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		// It does not exist, so nothing to do
+		return fmt.Errorf("Path does not exist: %s", path)
+	}
+	// It exists, so make sure it is a directory
+	if !dirInfo.IsDir() {
+		return fmt.Errorf("Path exists but is not a directory: %s", path)
+	}
+	// Remove it
+	return os.Remove(path)
 }
 
 func SetTestService(service string) {
@@ -572,6 +595,8 @@ func UnsetTestService() {
 }
 
 func InitArtifacts() {
+	var err error
+
 	artifactDirectory = os.Getenv("ARTIFACTS")
 	if len(artifactDirectory) == 0 {
 		if len(logFileDir) == 0 {
@@ -581,15 +606,58 @@ func InitArtifacts() {
 		// Default to log_directory/timestamp
 		artifactDirectory = logFileDir + "/" + "artifacts-" + time.Now().Format(time.RFC3339Nano)
 		Debugf("ARTIFACTS environment variable not set. Defaulting to '%s'", artifactDirectory)
+	} else {
+		Debugf("ARTIFACTS environment variable set to '%s'", artifactDirectory)
 	}
-	err := CreateDirectoryIfNeeded(artifactDirectory)
+	err, artifactDirectoryCreated = CreateDirectoryIfNeeded(artifactDirectory)
 	if err != nil {
 		Warnf(err.Error())
 		Warnf("Error with artifact directory \"%s\"; no artifacts will be saved", artifactDirectory)
 		artifactDirectory = ""
 		return
 	}
-	Infof("artifactDirectory=" + artifactDirectory)
+	Infof("artifactDirectory=%s", artifactDirectory)
+}
+
+func CompressArtifacts() {
+	if len(artifactDirectory) == 0 {
+		// No artifact directory set, so nothing to do.
+		return
+	}
+	if !artifactsLogged {
+		// No artifacts logged, but there is an artifact directory.
+		// If we created it, then we will delete it.
+		if !artifactDirectoryCreated {
+			Debugf("No artifacts saved. We did not create the artifact directory, so we will not remove it.")
+			return
+		}
+		Infof("No artifacts saved. Removing empty artifact directory: '%s'", artifactDirectory)
+		err := RemoveEmptyDirectory(artifactDirectory)
+		artifactDirectory = ""
+		if err != nil {
+			Warnf(err.Error())
+		}
+		return
+	}
+	// Artifacts were logged, so compress them and delete the uncompressed artifacts
+	compressedArtifactsFile := artifactDirectory + ".tar.bz2"
+	Infof("Compressing saved test artifacts to '%s'", compressedArtifactsFile)
+	artifactParentDirectory := filepath.Dir(artifactDirectory)
+	artifactDirectoryBasename := filepath.Base(artifactDirectory)
+	Debugf("artifactParentDirectory=%s, artifactDirectoryBasename=%s", artifactParentDirectory,
+		artifactDirectoryBasename)
+	cmdResult, err := RunName("tar", "-C", artifactParentDirectory, "--remove-files", "--bzip2",
+		"-cvf", compressedArtifactsFile, artifactDirectoryBasename)
+	artifactDirectory = ""
+	if err != nil {
+		Warnf(err.Error())
+		return
+	}
+	if cmdResult.Rc == 0 {
+		// Command passed
+		return
+	}
+	Warnf("Error compressing artifacts (tar return code = %d)", cmdResult.Rc)
 }
 
 func init() {
@@ -598,7 +666,7 @@ func init() {
 	runTags = append(runTags, AlnumString(5))
 	logFile, testLog = nil, nil
 	printInfo, printWarn, printError, printResults = true, true, true, true
-	printVerbose = false
+	artifactDirectoryCreated, artifactsLogged, printVerbose = false, false, false
 	runTag, artifactDirectory, artifactFilePrefix, testService, logFileDir = "", "", "", "", ""
 	// Call the init function for the printlog source file
 	printlogInit()

--- a/cmsdev/internal/lib/common/printlog.go
+++ b/cmsdev/internal/lib/common/printlog.go
@@ -361,7 +361,7 @@ func CreateLogFile(path, version string, logs, retry, quiet, verbose bool) {
 	} else if len(path) == 0 {
 		path = DEFAULT_LOG_FILE_DIR
 	}
-	err = CreateDirectoryIfNeeded(path)
+	err, _ = CreateDirectoryIfNeeded(path)
 	if err != nil {
 		fmt.Printf("Error with log directory: %s\n", path)
 		panic(err)

--- a/cmsdev/internal/lib/common/printlog.go
+++ b/cmsdev/internal/lib/common/printlog.go
@@ -49,6 +49,7 @@ const DEFAULT_LOG_FILE_DIR string = "/opt/cray/tests/install/logs/cmsdev"
 const RELATIVE_PATH_TO_THIS_FILE = "cmsdev/internal/lib/common/printlog.go"
 
 var srcPrefixSubstring string
+var logFileDir string
 
 // log file handle
 var logFile *logrus.Logger
@@ -391,6 +392,7 @@ func CreateLogFile(path, version string, logs, retry, quiet, verbose bool) {
 	}
 	runTag = strings.Join(runTags, "-")
 	testLog = logFile.WithFields(logrus.Fields{"version": version, "args": strings.Join(args, ",")})
+	logFileDir = path
 	Infof("cmsdev starting")
 	fmt.Printf("Starting main run, version: %s, tag: %s\n", version, runTag)
 }

--- a/cmsdev/internal/lib/common/printlog.go
+++ b/cmsdev/internal/lib/common/printlog.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -43,7 +43,7 @@ import (
 	"time"
 )
 
-const DEFAULT_LOG_FILE_DIR string = "/opt/cray/tests"
+const DEFAULT_LOG_FILE_DIR string = "/opt/cray/tests/install/logs/cmsdev"
 
 // Relative path to this source file within its repo
 const RELATIVE_PATH_TO_THIS_FILE = "cmsdev/internal/lib/common/printlog.go"

--- a/cmsdev/internal/test/bos/bos.go
+++ b/cmsdev/internal/test/bos/bos.go
@@ -110,7 +110,13 @@ func IsBOSRunning() (passed bool) {
 	}
 
 	if !passed {
-		common.ArtifactsPodsPvcs(podNames, pvcNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
+		if len(pvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
+		}
 	}
 
 	// Defined in bos_api.go

--- a/cmsdev/internal/test/cfs/cfs.go
+++ b/cmsdev/internal/test/cfs/cfs.go
@@ -114,7 +114,10 @@ func IsCFSRunning() (passed bool) {
 		passed = false
 	}
 	if !passed {
-		common.ArtifactsPods(podNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
 	}
 	return
 }

--- a/cmsdev/internal/test/conman/conman.go
+++ b/cmsdev/internal/test/conman/conman.go
@@ -66,7 +66,13 @@ func IsConmanRunning() (passed bool) {
 	}
 
 	if !passed {
-		common.ArtifactsPodsPvcs(allPodNames, allPvcNames)
+		common.ArtifactsKubernetes()
+		if len(allPodNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, allPodNames)
+		}
+		if len(allPvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, allPvcNames)
+		}
 	}
 	return
 }

--- a/cmsdev/internal/test/ims/ims.go
+++ b/cmsdev/internal/test/ims/ims.go
@@ -62,7 +62,13 @@ func IsIMSRunning() (passed bool) {
 	}
 
 	if !passed {
-		common.ArtifactsPodsPvcs(podNames, pvcNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
+		if len(pvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
+		}
 		artifactsCollected = true
 	}
 
@@ -140,7 +146,13 @@ func IsIMSRunning() (passed bool) {
 	}
 
 	if !passed && !artifactsCollected {
-		common.ArtifactsPodsPvcs(podNames, pvcNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
+		if len(pvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
+		}
 		artifactsCollected = true
 	}
 
@@ -277,7 +289,13 @@ func IsIMSRunning() (passed bool) {
 	}
 
 	if !passed && !artifactsCollected {
-		common.ArtifactsPodsPvcs(podNames, pvcNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
+		if len(pvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
+		}
 		artifactsCollected = true
 	}
 

--- a/cmsdev/internal/test/ipxe_tftp/ipxe_tftp.go
+++ b/cmsdev/internal/test/ipxe_tftp/ipxe_tftp.go
@@ -85,7 +85,13 @@ func AreTheyRunning() (passed bool) {
 	}
 
 	if !passed {
-		common.ArtifactsPodsPvcs(podNames, pvcNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
+		if len(pvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
+		}
 		common.Infof("Because of previous failures, skipping remaining tftp checks")
 		return
 	}

--- a/cmsdev/internal/test/vcs/vcs.go
+++ b/cmsdev/internal/test/vcs/vcs.go
@@ -174,7 +174,13 @@ func IsVCSRunning() (passed bool) {
 	}
 
 	if !passed {
-		common.ArtifactsPodsPvcs(podNames, pvcNames)
+		common.ArtifactsKubernetes()
+		if len(podNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
+		}
+		if len(pvcNames) > 0 {
+			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
+		}
 	}
 
 	if !repoTest() {


### PR DESCRIPTION
## Summary and Scope

This is to make it easier to debug some of the failures seen on automated test runs when the test environment is not available for live debug.

No change to the tests themselves, just to the logic around the Kubernetes debug data collection.

## Testing

Tested on wasp to make sure it works as expected in the normal case, as well as if an alternate Kubernetes artifact directory is specified, or if no logging is specified, or both.

## Risks and Mitigations

Low risk.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
