### PR TITLE
CASMCMS-8549: cmsdev: Add list of valid tests to --help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: Add list of service tests to --help output.
+
 ## [1.11.9] - 2023-04-07
 
 ### Changed


### PR DESCRIPTION
## Summary and Scope

This PR modifies the cmsdev test tool so that its extended help message (displayed when you run `cmsdev test -h`) includes a list of the valid tests it can run.

As part of implementing that, I consolidated some redundant code into a common function used to generate this list.

## Testing

I tested this on wasp and verified that it still behaves as usual when running tests, but that the help message now includes the intended test list.

## Risks and Mitigations

Low risk -- no change to the tests themselves.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
