### PR TITLE
CASMCMS-8602: cmsdev: Update iPXE/TFTP test to use cray-ipxe-settings configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev: iPXE/TFTP test improvements:
+  - Now uses cray-ipxe-settings ConfigMap to determine which iPXE binaries are being built and what their names are
+  - Now tests TFTP file transfer test for all binaries being built.
+
 ## [1.11.10] - 2023-04-27
 
 ### Changed

--- a/cmsdev/internal/lib/common/helpers.go
+++ b/cmsdev/internal/lib/common/helpers.go
@@ -27,6 +27,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"os"
 	"reflect"
 	"regexp"
@@ -35,6 +36,15 @@ import (
 func DecodeJSONIntoStringMap(mapJsonBytes []byte) (map[string]interface{}, error) {
 	var m map[string]interface{}
 	err := json.Unmarshal(mapJsonBytes, &m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func DecodeYAMLIntoStringMap(mapYamlBytes []byte) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	err := yaml.Unmarshal(mapYamlBytes, &m)
 	if err != nil {
 		return nil, err
 	}
@@ -126,8 +136,52 @@ func GetStringFieldFromMap(fieldName string, mapJsonBytes []byte) (fieldValue st
 	return
 }
 
+func GetBoolFieldFromMapObjectWithDefault(fieldName string, mapObject map[string]interface{}, defaultValue bool) (fieldValue bool, err error) {
+	Debugf("Getting value of \"%s\" field from map object (value should be boolean)", fieldName)
+	fieldValue = defaultValue
+
+	fieldRawValue, ok := mapObject[fieldName]
+	if !ok {
+		Debugf("Map does not have \"%s\" field, returning default value \"%t\"", fieldName, defaultValue)
+		return
+	}
+
+	fieldValue, ok = fieldRawValue.(bool)
+	if !ok {
+		err = fmt.Errorf(
+			"Map has \"%s\" field but its value is type %s, not bool",
+			fieldName, reflect.TypeOf(fieldRawValue).String())
+		return
+	}
+
+	Debugf("Value of \"%s\" field in map object is \"%t\"", fieldName, fieldValue)
+	return
+}
+
+func GetStringFieldFromMapObjectWithDefault(fieldName string, mapObject map[string]interface{}, defaultValue string) (fieldValue string, err error) {
+	Debugf("Getting value of \"%s\" field from map object (value should be a string)", fieldName)
+	fieldValue = defaultValue
+
+	fieldRawValue, ok := mapObject[fieldName]
+	if !ok {
+		Debugf("Map does not have \"%s\" field, returning default value \"%s\"", fieldName, defaultValue)
+		return
+	}
+
+	fieldValue, ok = fieldRawValue.(string)
+	if !ok {
+		err = fmt.Errorf(
+			"Map has \"%s\" field but its value is type %s, not string",
+			fieldName, reflect.TypeOf(fieldRawValue).String())
+		return
+	}
+
+	Debugf("Value of \"%s\" field in map object is \"%s\"", fieldName, fieldValue)
+	return
+}
+
 func GetStringFieldFromMapObject(fieldName string, mapObject map[string]interface{}) (fieldValue string, err error) {
-	Debugf("Getting value of \"%s\" field from map object", fieldName)
+	Debugf("Getting value of \"%s\" field from map object (value should be a string)", fieldName)
 
 	fieldRawValue, ok := mapObject[fieldName]
 	if !ok {

--- a/cmsdev/internal/lib/k8s/k8s.go
+++ b/cmsdev/internal/lib/k8s/k8s.go
@@ -385,6 +385,28 @@ func GetConfigMap(namespace, name string) (cm coreV1.ConfigMap, err error) {
 	return
 }
 
+// Given a namespace, configmap name, and data field name, return the specified data field as a byte slice.
+func GetConfigMapDataField(namespace, cm_name, field_name string) (field_bytes []byte, err error) {
+	var cm coreV1.ConfigMap
+
+	cm, err = GetConfigMap(namespace, cm_name)
+	if err != nil {
+		return
+	}
+
+	common.Debugf("Retrieve Data field '%s' from ConfigMap '%s' in namespace '%s'", field_name, cm_name, namespace)
+	dataField, keyFound := cm.Data[field_name]
+	if !keyFound {
+		err = fmt.Errorf("No field named '%s' found in Kubernetes ConfigMap %s in namespace %s", field_name, cm_name, namespace)
+		return
+	}
+
+	// Make sure we can convert the field to a byte slice
+	common.Debugf("Convert %s field to byte slice", field_name)
+	field_bytes = []byte(dataField)
+	return
+}
+
 // Given a namespace and name, returns the matching service
 func GetService(namespace, name string) (service coreV1.Service, err error) {
 	clientset, err := GetClientset()


### PR DESCRIPTION
## Summary and Scope

The cmsdev ipxe test includes validating that the iPXE image is being generated and that it can be downloaded over tftp. However, the test currently only does this for the regular iPXE binary, not the debug binary. It also has the name of the binary hard-coded to be the default value, AND it assumes that the binary is being built. However, the cray-ipxe-settings configmap can be modified so that the name of the binary is not the default, or so that it is not being built at all. Currently the test will fail in such situations.

This PR makes the following improvements to this test:
1) The test now covers both the regular binary and the debug binary
2) The test uses the ConfigMap to determine the names of the binaries
3) The test uses the ConfigMap to determine whether or not the binaries are being built

## Issues and Related PRs

* Resolves [CASMCMS-8602](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8602)
* Lays some groundwork for the changes needed for adding ARM support with [CASMCMS-8504](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8504)

## Testing

I tested this on drax and starlord. I tested the default path (where the configmap contains the unmodified default values), as well as the following scenarios:
* x86 image builds are disabled in the config map
* The binary name in the config map is non-standard
* The debug binary name in the config map is non-standard

## Risks and Mitigations

Low risk. On most systems, the only change will end be that the debug binary is also included in the test. But for systems where the defaults have been changed, this will allow the test to work properly.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
