### PR TITLE
CASMTRIAGE-5598: cmsdev: Compress artifacts using gzip instead of bzip2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.9] - 2023-06-27
+
+### Fixed
+
+- cmsdev: Compress artifacts using gzip instead of bzip2
+
 ## [1.10.8] - 2023-04-07
 
 ### Changed

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -652,14 +652,14 @@ func CompressArtifacts() {
 		return
 	}
 	// Artifacts were logged, so compress them and delete the uncompressed artifacts
-	compressedArtifactsFile := artifactDirectory + ".tar.bz2"
+	compressedArtifactsFile := artifactDirectory + ".tgz"
 	Infof("Compressing saved test artifacts to '%s'", compressedArtifactsFile)
 	artifactParentDirectory := filepath.Dir(artifactDirectory)
 	artifactDirectoryBasename := filepath.Base(artifactDirectory)
 	Debugf("artifactParentDirectory=%s, artifactDirectoryBasename=%s", artifactParentDirectory,
 		artifactDirectoryBasename)
-	cmdResult, err := RunName("tar", "-C", artifactParentDirectory, "--remove-files", "--bzip2",
-		"-cvf", compressedArtifactsFile, artifactDirectoryBasename)
+	cmdResult, err := RunName("tar", "-C", artifactParentDirectory, "--remove-files",
+		"-czvf", compressedArtifactsFile, artifactDirectoryBasename)
 	artifactDirectory = ""
 	if err != nil {
 		Warnf(err.Error())


### PR DESCRIPTION
## Summary and Scope

bzip2 is not available on all systems. gzip is more universally available, so this changes cmsdev to use it when compressing test artifacts in the case of failure.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5598](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5598)
* [Backport to master](https://github.com/Cray-HPE/cms-tools/pull/112)

## Testing

I tested this on drax. I redeployed the tftp pod and ran the test before it was done restarting. This caused the test to fail, as expected. I verified that it correctly compressed the artifacts using gzip.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
