### PR TITLE
CASMTRIAGE-5598: cmsdev: Compress artifacts using gzip instead of bzip2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.13] - 2023-06-27
+
+### Fixed
+
+- cmsdev: Compress artifacts using gzip instead of bzip2
+
 ## [1.11.12] - 2023-06-21
 
 ### Added

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -640,14 +640,14 @@ func CompressArtifacts() {
 		return
 	}
 	// Artifacts were logged, so compress them and delete the uncompressed artifacts
-	compressedArtifactsFile := artifactDirectory + ".tar.bz2"
+	compressedArtifactsFile := artifactDirectory + ".tgz"
 	Infof("Compressing saved test artifacts to '%s'", compressedArtifactsFile)
 	artifactParentDirectory := filepath.Dir(artifactDirectory)
 	artifactDirectoryBasename := filepath.Base(artifactDirectory)
 	Debugf("artifactParentDirectory=%s, artifactDirectoryBasename=%s", artifactParentDirectory,
 		artifactDirectoryBasename)
-	cmdResult, err := RunName("tar", "-C", artifactParentDirectory, "--remove-files", "--bzip2",
-		"-cvf", compressedArtifactsFile, artifactDirectoryBasename)
+	cmdResult, err := RunName("tar", "-C", artifactParentDirectory, "--remove-files",
+		"-czvf", compressedArtifactsFile, artifactDirectoryBasename)
 	artifactDirectory = ""
 	if err != nil {
 		Warnf(err.Error())


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/cms-tools/pull/111 to master