### PR TITLE
CASMCMS-8504: cmsdev: Added support for ARM binaries to iPXE/TFTP test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2023-06-27
+
+### Added
+
+- cmsdev: Added support for ARM binaries to iPXE/TFTP test
+
 ## [1.11.13] - 2023-06-27
 
 ### Fixed
@@ -183,7 +189,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.11.11...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.12.0...HEAD
+
+[1.12.0]: https://github.com/Cray-HPE/cms-tools/compare/1.11.13...1.12.0
+
+[1.11.13]: https://github.com/Cray-HPE/cms-tools/compare/1.11.12...1.11.13
+
+[1.11.12]: https://github.com/Cray-HPE/cms-tools/compare/1.11.11...1.11.12
 
 [1.11.11]: https://github.com/Cray-HPE/cms-tools/compare/1.11.10...1.11.11
 


### PR DESCRIPTION
## Summary and Scope

This PR updates the iPXE/TFTP test so that it tests transferring Arm binaries as well as x86 binaries. It covers both debug and regular, and looks at the configmap to determine which ones are being built (and thus should be tested).

## Issues and Related PRs

* Resolves [CASMCMS-8504](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8504)
* Resolves [CASMTRIAGE-5597](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5597)

## Testing

I tested the updated version on ashton (installed with 1.5.0-alpha.66) and verified that it worked as expected.

## Risks and Mitigations

Without this test change, the ipxe/tftp test will always fail on CSM 1.5.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
