### PR TITLE
CASMCMS-8553: Add good path multitenancy testing for BOS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- cmsdev
+  - Simplified `lib.common.Restful()` function
+
 ## [1.13.0] - 2023-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - cmsdev
   - Simplified `lib.common.Restful()` function
-  - Added good path BOS API tests with tenant specified for `/v2`, `/v2/healthz`, and `/v2/version` endpoints.
+  - Added good path BOS API GET tests with tenant specified for supported v2 endpoints
 
 ## [1.13.0] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - cmsdev
   - Simplified `lib.common.Restful()` function
+  - Added good path BOS API tests with tenant specified for `/v2`, `/v2/healthz`, and `/v2/version` endpoints.
 
 ## [1.13.0] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmsdev
   - Simplified `lib.common.Restful()` function
   - Added good path BOS API GET tests with tenant specified for supported v2 endpoints
+  - Updated v2 sessions CLI, session templates CLI (v1 and v2), and v1 session templates API tests to
+    handle multi-tenancy in their responses from BOS (while not including it in their queries to BOS).
 
 ## [1.13.0] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2023-08-14
+
 ### Changed
 
 - cmsdev
@@ -216,7 +218,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.13.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.14.0...HEAD
+
+[1.14.0]: https://github.com/Cray-HPE/cms-tools/compare/1.13.0...1.14.0
 
 [1.13.0]: https://github.com/Cray-HPE/cms-tools/compare/1.12.0...1.13.0
 

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -479,20 +479,10 @@ func PrintEndpoints(service string, params ...string) {
 	}
 }
 
-// Restful() performs CMS RESTful calls
-// returns true on success, otherwise false
-// returns populated message string if success == false
-func Restful(method, url string, params Params) (*resty.Response, error) {
+// doRest() performs RESTful calls using the provided client and parameters.
+func doRest(method, url string, params Params, client *resty.Client) (*resty.Response, error) {
 	var err error
 	var resp *resty.Response
-
-	client := resty.New()
-	client.SetHeaders(map[string]string{
-		"Accept":       "application/json",
-		"User-Agent":   "cmsdev",
-		"Content-Type": "application/json",
-	})
-	client.SetAuthToken(params.Token)
 
 	switch method {
 	case "GET":
@@ -518,6 +508,31 @@ func Restful(method, url string, params Params) (*resty.Response, error) {
 	}
 
 	return resp, err
+}
+
+// Restful() performs CMS RESTful calls
+func Restful(method, url string, params Params) (*resty.Response, error) {
+	client := resty.New()
+	client.SetHeaders(map[string]string{
+		"Accept":       "application/json",
+		"User-Agent":   "cmsdev",
+		"Content-Type": "application/json",
+	})
+	client.SetAuthToken(params.Token)
+	return doRest(method, url, params, client)
+}
+
+// Restful() performs CMS RESTful calls on behalf of the specified tenant
+func RestfulTenant(method, url, tenant string, params Params) (*resty.Response, error) {
+	client := resty.New()
+	client.SetHeaders(map[string]string{
+		"Accept":           "application/json",
+		"User-Agent":       "cmsdev",
+		"Content-Type":     "application/json",
+		"Cray-Tenant-Name": tenant,
+	})
+	client.SetAuthToken(params.Token)
+	return doRest(method, url, params, client)
 }
 
 func CreateDirectoryIfNeeded(path string) (error, bool) {

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -487,53 +487,37 @@ func Restful(method, url string, params Params) (*resty.Response, error) {
 	var resp *resty.Response
 
 	client := resty.New()
+	client.SetHeaders(map[string]string{
+		"Accept":       "application/json",
+		"User-Agent":   "cmsdev",
+		"Content-Type": "application/json",
+	})
+	client.SetAuthToken(params.Token)
 
 	switch method {
 	case "GET":
-		client.SetHeaders(map[string]string{
-			"Accept":     "application/json",
-			"User-Agent": "cmsdev",
-		})
-		resp, err = client.R().
-			SetAuthToken(params.Token).
-			Get(url)
+		resp, err = client.R().Get(url)
 	case "POST":
 		if len(params.JsonStr) != 0 {
 			// payload passed as string
 			resp, err = client.R().
-				SetAuthToken(params.Token).
-				SetHeader("Content-Type", "application/json").
 				SetBody(params.JsonStr).
 				Post(url)
 		} else {
 			// payload passed as byte array
 			resp, err = client.R().
-				SetAuthToken(params.Token).
-				SetHeader("Content-Type", "application/json").
 				SetBody(params.JsonStrArray).
 				Post(url)
 		}
 	case "PATCH":
-		client.SetHeaders(map[string]string{
-			"Accept":     "application/json",
-			"User-Agent": "cmsdev",
-		})
 		resp, err = client.R().
-			SetAuthToken(params.Token).
 			SetBody(params.JsonStrArray).
 			Patch(url)
 	case "DELETE":
-		client.SetHeaders(map[string]string{
-			"Content-Type": "application/json",
-			"User-Agent":   "cmsdev",
-		})
-		resp, err = client.R().
-			SetAuthToken(params.Token).
-			Delete(url)
+		resp, err = client.R().Delete(url)
 	}
 
 	return resp, err
-
 }
 
 func CreateDirectoryIfNeeded(path string) (error, bool) {

--- a/cmsdev/internal/lib/common/rand.go
+++ b/cmsdev/internal/lib/common/rand.go
@@ -22,6 +22,7 @@
 package common
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -59,6 +60,18 @@ func Float32() float32 {
 
 func Float64() float64 {
 	return myRand.Float64()
+}
+
+// Return a random string from a list of strings
+// Only returns error in the case that the list is empty
+func GetRandomStringFromList(stringList []string) (randString string, err error) {
+	if len(stringList) > 0 {
+		listIndex := IntInRange(0, len(stringList)-1)
+		randString = stringList[listIndex]
+	} else {
+		err = fmt.Errorf("GetRandomStringFromList: Cannot choose a string from an empty list")
+	}
+	return
 }
 
 // Generate a random string of the specified length from the specified characters

--- a/cmsdev/internal/lib/k8s/k8s.go
+++ b/cmsdev/internal/lib/k8s/k8s.go
@@ -105,6 +105,24 @@ func GetKubectlPath() (string, error) {
 	return KubectlPath, nil
 }
 
+func GetTenants() (tenantList []string, err error) {
+	var path string
+	var cmdList = []string{"get", "tenants", "-n", "tenants", "-o", "custom-columns=:.metadata.name ", "--no-headers"}
+	path, err = GetKubectlPath()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(path, cmdList...)
+	common.Debugf("Running command: %s", cmd)
+	cmdOut, err := cmd.CombinedOutput()
+	if err != nil {
+		return
+	}
+	// Trim final newline and split by newline
+	tenantList = strings.Split(strings.TrimSpace(string(cmdOut)), "\n")
+	return
+}
+
 func RunCommandInContainer(podName, namespace, containerName string, cmdStrings ...string) (string, error) {
 	k8sCmdList := [...]string{"exec", podName, "-n", namespace, "-c", containerName, "--stdin=false", "--"}
 	cmdList := append(k8sCmdList[:], cmdStrings...)

--- a/cmsdev/internal/lib/k8s/k8s.go
+++ b/cmsdev/internal/lib/k8s/k8s.go
@@ -118,8 +118,15 @@ func GetTenants() (tenantList []string, err error) {
 	if err != nil {
 		return
 	}
-	// Trim final newline and split by newline
-	tenantList = strings.Split(strings.TrimSpace(string(cmdOut)), "\n")
+	// Trim whitespace
+	tenantListString := strings.TrimSpace(string(cmdOut))
+	if len(tenantListString) == 0 {
+		common.Infof("No tenants defined on the system")
+		return
+	}
+	// Split by newline
+	tenantList = strings.Split(tenantListString, "\n")
+	common.Infof("The following %d tenants are defined on the system: %s", len(tenantList), strings.Join(tenantList, ", "))
 	return
 }
 

--- a/cmsdev/internal/lib/test/api.go
+++ b/cmsdev/internal/lib/test/api.go
@@ -75,6 +75,23 @@ func RestfulVerifyStatus(method, url string, params common.Params, ExpectedStatu
 	return
 }
 
+func TenantRestfulVerifyStatus(method, url, tenant string, params common.Params, ExpectedStatus int) (resp *resty.Response, err error) {
+	common.Infof("%s %s (tenant: %s)", method, url, tenant)
+	resp, err = common.RestfulTenant(method, url, tenant, params)
+	if err != nil {
+		err = fmt.Errorf("%s %s (tenant: %s) failed: %v", method, url, tenant, err)
+		return
+	}
+	common.Debugf("resp=%v", resp)
+	common.PrettyPrintJSON(resp)
+	if resp.StatusCode() != ExpectedStatus {
+		err = fmt.Errorf("%s %s (tenant: %s): expected status code %d, got %d", method, url, tenant, ExpectedStatus, resp.StatusCode())
+		return
+	}
+	common.Infof("Received status code %d, as expected", resp.StatusCode())
+	return
+}
+
 func RestfulTestResultSummary(numFailed, testTotal int) {
 	common.Infof("%d passed, %d failed", testTotal-numFailed, numFailed)
 }

--- a/cmsdev/internal/test/bos/bos_api.go
+++ b/cmsdev/internal/test/bos/bos_api.go
@@ -46,11 +46,32 @@ func bosRestfulVerifyStatus(method, uri string, params *common.Params, ExpectedS
 	return test.RestfulVerifyStatus(method, bosBaseUrl+uri, *params, ExpectedStatus)
 }
 
+func bosTenantRestfulVerifyStatus(method, uri, tenant string, params *common.Params, ExpectedStatus int) (*resty.Response, error) {
+	return test.TenantRestfulVerifyStatus(method, bosBaseUrl+uri, tenant, *params, ExpectedStatus)
+}
+
 // Given a BOS URI, do a GET request to it. Verify that the response has 200 status code and returns a dictionary (aka string map) object.
 // Return true if all of that worked fine. Otherwise, log an appropriate error and return false.
 func basicGetUriVerifyStringMapTest(uri string, params *common.Params) bool {
 	common.Infof("GET %s test scenario", uri)
 	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// Validate that object can be decoded into a string map at least
+	_, err = common.DecodeJSONIntoStringMap(resp.Body())
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+	return true
+}
+
+func basicTenantGetUriVerifyStringMapTest(uri, tenant string, params *common.Params) bool {
+	common.Infof("GET %s (tenant: %s) test scenario", uri, tenant)
+	resp, err := bosTenantRestfulVerifyStatus("GET", uri, tenant, params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
 		return false

--- a/cmsdev/internal/test/bos/bos_api.go
+++ b/cmsdev/internal/test/bos/bos_api.go
@@ -87,7 +87,7 @@ func basicTenantGetUriVerifyStringMapTest(uri, tenant string, params *common.Par
 }
 
 // Run all of the BOS API subtests. Return true if they all pass, false otherwise.
-func apiTests() (passed bool) {
+func apiTests(tenantList []string) (passed bool) {
 	passed = true
 
 	params := test.GetAccessTokenParams()
@@ -96,17 +96,17 @@ func apiTests() (passed bool) {
 	}
 
 	// Defined in bos_version.go
-	if !versionTestsAPI(params) {
+	if !versionTestsAPI(params, tenantList) {
 		passed = false
 	}
 
 	// Defined in bos_healthz.go
-	if !healthzTestsAPI(params) {
+	if !healthzTestsAPI(params, tenantList) {
 		passed = false
 	}
 
 	// Defined in bos_components.go
-	if !componentsTestsAPI(params) {
+	if !componentsTestsAPI(params, tenantList) {
 		passed = false
 	}
 
@@ -116,12 +116,12 @@ func apiTests() (passed bool) {
 	}
 
 	// Defined in bos_sessiontemplate.go
-	if !sessionTemplatesTestsAPI(params) {
+	if !sessionTemplatesTestsAPI(params, tenantList) {
 		passed = false
 	}
 
 	// Defined in bos_session.go
-	if !sessionsTestsAPI(params) {
+	if !sessionsTestsAPI(params, tenantList) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_cli.go
+++ b/cmsdev/internal/test/bos/bos_cli.go
@@ -52,6 +52,28 @@ func runBosCLIDescribe(target string, cmdArgs ...string) []byte {
 	return runBosCLI(newCmdArgs...)
 }
 
+// Runs a BOS CLI list with the specified arguments (with no tenant specified)
+// Parses the result to convert it to a list of dictionaries with string keys
+// Returns the result and a boolean indicating whether or not this was successful (true == no errors)
+func bosListCli(cmdArgs ...string) (dictList []map[string]interface{}, passed bool) {
+	var err error
+
+	passed = false
+	cmdOut := runBosCLIList(cmdArgs...)
+	if cmdOut == nil {
+		return
+	}
+
+	// Decode JSON into a list of string maps
+	dictList, err = common.DecodeJSONIntoStringMapList(cmdOut)
+	if err != nil {
+		common.Error(err)
+		return
+	}
+	passed = true
+	return
+}
+
 // Given a BOS CLI command prefix, run that CLI command with "list" appended to the end.
 // Verify that the command succeeded and returns a dictionary (aka string map) object.
 // Return true if all of that worked fine. Otherwise, log an appropriate error and return false.

--- a/cmsdev/internal/test/bos/bos_healthz.go
+++ b/cmsdev/internal/test/bos/bos_healthz.go
@@ -55,6 +55,11 @@ func healthzTestsAPI(params *common.Params) (passed bool) {
 		passed = false
 	}
 
+	// v2 endpoint as random tenant (BOS does not verify if tenant exists for GET operations)
+	if !basicTenantGetUriVerifyStringMapTest(bosV2HealthzUri, "cmsdev-tenant", params) {
+		passed = false
+	}
+
 	return
 }
 

--- a/cmsdev/internal/test/bos/bos_healthz.go
+++ b/cmsdev/internal/test/bos/bos_healthz.go
@@ -39,7 +39,7 @@ const bosV1HealthzCLI = "healthz"
 const bosV2HealthzCLI = "healthz"
 const bosDefaultHealthzCLI = bosV2HealthzCLI
 
-func healthzTestsAPI(params *common.Params) (passed bool) {
+func healthzTestsAPI(params *common.Params, tenantList []string) (passed bool) {
 	passed = true
 
 	// Just do a GET of the options endpoint and make sure that the response has
@@ -56,7 +56,7 @@ func healthzTestsAPI(params *common.Params) (passed bool) {
 	}
 
 	// v2 endpoint as random tenant (BOS does not verify if tenant exists for GET operations)
-	if !basicTenantGetUriVerifyStringMapTest(bosV2HealthzUri, "cmsdev-tenant", params) {
+	if !basicTenantGetUriVerifyStringMapTest(bosV2HealthzUri, getAnyTenant(tenantList), params) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_session.go
+++ b/cmsdev/internal/test/bos/bos_session.go
@@ -29,7 +29,11 @@ package bos
  */
 
 import (
+	"errors"
+	"fmt"
+	resty "gopkg.in/resty.v1"
 	"net/http"
+	"reflect"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 )
 
@@ -39,6 +43,106 @@ const bosV2SessionsUri = bosV2BaseUri + "/sessions"
 const bosV1SessionsCLI = "session"
 const bosV2SessionsCLI = "sessions"
 const bosDefaultSessionsCLI = bosV2SessionsCLI
+
+// A BOS v2 session is uniquely identified by its name and tenant. The tenant may null, blank,
+// or, equivalently, not present in the actual record. In all such cases, the
+// following struct uses an empty string value for Tenant.
+type v2SessionData struct {
+	Name, Tenant string
+}
+
+// Returns true if the Name field of the object is "", false otherwise
+func (sessionData v2SessionData) IsNil() bool {
+	return sessionData.Name == ""
+}
+
+// Returns a string representation of the object
+func (sessionData v2SessionData) String() string {
+	if len(sessionData.Tenant) > 0 {
+		return fmt.Sprintf("name: '%s', tenant: '%s'", sessionData.Name, sessionData.Tenant)
+	}
+	return fmt.Sprintf("name: '%s', no tenant", sessionData.Name)
+}
+
+// Compares two objects. Returns true if both fields match, false otherwise. If false,
+// appropriate errors are also logged noting the discrepancies
+func (sessionData v2SessionData) HasExpectedValues(expectedSessionData v2SessionData) (passed bool) {
+	// Let's be optimistic and assume that they will match
+	passed = true
+
+	// Validate that name fields match
+	if sessionData.Name != expectedSessionData.Name {
+		common.Errorf("BOS session name '%s' does not match expected name '%s'", sessionData.Name, expectedSessionData.Name)
+		passed = false
+	} else {
+		common.Debugf("BOS session name '%s' matches expected value", sessionData.Name)
+	}
+
+	// Validate the tenant name
+	if sessionData.Tenant == expectedSessionData.Tenant {
+		if len(sessionData.Tenant) == 0 {
+			common.Debugf("Session does not belong to a tenant, which matches expectations")
+		} else {
+			common.Debugf("Session belongs to the expected tenant")
+		}
+		return
+	}
+	passed = false
+	if len(sessionData.Tenant) == 0 {
+		common.Errorf("Session does not belong to a tenant, but it should belong to '%s'", expectedSessionData.Tenant)
+	} else {
+		common.Errorf("Session belongs to tenant '%s', but it should not belong to any tenant", sessionData.Tenant)
+	}
+	return
+}
+
+// Takes as input a mapping from strings to arbitrary objects.
+// Parses it to extract the values of the 'name' and 'tenant' fields (although the
+// latter is allowed to be absent). Validates that 'name' (and 'tenant', if present and non-null)
+// have string values and that 'name' is non-0 length. Returns a v2SessionData object
+// populated from those fields. Returns an error with any problems encountered.
+func parseV2SessionData(sessionDict map[string]interface{}) (sessionData v2SessionData, totalErr error) {
+	var err error
+	var fieldFound, fieldIsString bool
+	var sessionTenantField interface{}
+
+	common.Debugf("Getting name of session")
+	sessionData.Name, err = common.GetStringFieldFromMapObject("name", sessionDict)
+	if err != nil {
+		err = fmt.Errorf("%w; Error getting 'name' field of BOS session", err)
+	} else if len(sessionData.Name) == 0 {
+		err = fmt.Errorf("BOS session has a 0-length name")
+	} else {
+		common.Debugf("Name of session is '%s'", sessionData.Name)
+	}
+	totalErr = errors.Join(totalErr, err)
+
+	common.Debugf("Checking for 'tenant' field of session '%s'", sessionData.Name)
+	sessionTenantField, fieldFound = sessionDict["tenant"]
+	if !fieldFound {
+		// This session has no tenant field, which is equivalent to a 0-length string tenant field
+		sessionData.Tenant = ""
+		common.Debugf("Session '%s' has no 'tenant' field", sessionData.Name)
+		return
+	}
+	if sessionTenantField == nil {
+		// This session has null-value tenant field, which is equivalent to a 0-length string tenant field
+		sessionData.Tenant = ""
+		common.Debugf("Session '%s' has null 'tenant' field", sessionData.Name)
+		return
+	}
+
+	// If it is present and non-null, it should be a string value
+	sessionData.Tenant, fieldIsString = sessionTenantField.(string)
+	if !fieldIsString {
+		// tenant field has non-string value
+		err = fmt.Errorf("Session '%s' has a non-null 'tenant' field but its value is type %s, not string",
+			sessionData.Name, reflect.TypeOf(sessionTenantField).String())
+		totalErr = errors.Join(totalErr, err)
+	}
+	common.Debugf("Session: %s", sessionData.String())
+	return
+}
 
 // The sessionsV1TestsURI, sessionsV2TestsURI, sessionsV1TestsCLICommand, and sessionsV2TestsCLICommand functions define the API and CLI versions of the
 // BOS v1 and v2 session subtests.
@@ -51,7 +155,7 @@ const bosDefaultSessionsCLI = bosV2SessionsCLI
 // 5. Verify that this succeeds and returns something of the right general form. For BOS v2, also verify that it has the expected name
 //    (in v1, the session ID is not in the returned object)
 
-func sessionsTestsAPI(params *common.Params) (passed bool) {
+func sessionsTestsAPI(params *common.Params, tenantList []string) (passed bool) {
 	passed = true
 
 	// v1 sessions
@@ -60,7 +164,7 @@ func sessionsTestsAPI(params *common.Params) (passed bool) {
 	}
 
 	// v2 sessions
-	if !sessionsV2TestsURI(bosV2SessionsUri, params) {
+	if !sessionsV2TestsURI(params, tenantList) {
 		passed = false
 	}
 
@@ -111,11 +215,11 @@ func sessionsV1TestsURI(uri string, params *common.Params) bool {
 	}
 
 	// a session_id is available
-	sessionId := stringList[0]
-	common.Infof("Found BOS v1 session with ID '%s'", sessionId)
+	sessionData := stringList[0]
+	common.Infof("Found BOS v1 session with ID '%s'", sessionData)
 
 	// test #2, describe session with session_id
-	uri += "/" + sessionId
+	uri += "/" + sessionData
 	if !basicGetUriVerifyStringMapTest(uri, params) {
 		return false
 	}
@@ -123,72 +227,250 @@ func sessionsV1TestsURI(uri string, params *common.Params) bool {
 	return true
 }
 
-// Given a response object (as an array of bytes), validate that:
-// 1. It resolves to a JSON dictonary
-// 2. That dictionary has a "name" field
-// 3. The "name" field of that dictionary has a value which matches our expectedName string
-//
-// Return true if all of the above is true. Otherwise, log an appropriate error and return false.
-func ValidateV2Session(mapCmdOut []byte, expectedName string) bool {
-	// For BOSv2, the session object we get back should have a 'name' field matching the name that we requested.
-	// So let's validate that
-	err := common.ValidateStringFieldValue("BOS session", "name", expectedName, mapCmdOut)
-	if err != nil {
-		common.Error(err)
-		return false
+// Performs an API query to get a particular BOS v2 session (possibly belonging to a tenant)
+// Parses the result to convert it to a dictionary with string keys
+// Returns the result and error (if any)
+func getV2SessionApi(params *common.Params, sessionData v2SessionData) (sessionDict map[string]interface{}, err error) {
+	var resp *resty.Response
+	uri := bosV2SessionsUri + "/" + sessionData.Name
+	if len(sessionData.Tenant) == 0 {
+		common.Infof("GET %s test scenario", uri)
+		resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	} else {
+		common.Infof("GET %s (tenant: %s) test scenario", uri, sessionData.Tenant)
+		resp, err = bosTenantRestfulVerifyStatus("GET", uri, sessionData.Tenant, params, http.StatusOK)
 	}
-	return true
+	if err != nil {
+		return
+	}
+	// Decode JSON into a string map
+	sessionDict, err = common.DecodeJSONIntoStringMap(resp.Body())
+	return
+}
+
+// Performs an API query to list BOS v2 sessions (possibly with a tenant specified)
+// Parses the result to convert it to a list of dictionaries with string keys
+// Returns the result and error (if any)
+func listV2SessionsApi(params *common.Params, tenantName string) (dictList []map[string]interface{}, err error) {
+	var resp *resty.Response
+	if len(tenantName) == 0 {
+		common.Infof("GET %s test scenario", bosV2SessionsUri)
+		resp, err = bosRestfulVerifyStatus("GET", bosV2SessionsUri, params, http.StatusOK)
+	} else {
+		common.Infof("GET %s (tenant: %s) test scenario", bosV2SessionsUri, tenantName)
+		resp, err = bosTenantRestfulVerifyStatus("GET", bosV2SessionsUri, tenantName, params, http.StatusOK)
+	}
+	if err != nil {
+		return
+	}
+	// Decode JSON into a list of string maps
+	dictList, err = common.DecodeJSONIntoStringMapList(resp.Body())
+	return
+}
+
+// Get a particular BOS v2 session (possibly belonging to a tenant) using getV2SessionApi,
+// parses that dictionaries into a v2SessionData struct.
+// Validates that it matches the expected session name and (if any) tenant name.
+// Returns that struct and error (if any)
+func getV2SessionDataApi(params *common.Params, sessionData v2SessionData) (sessionDataFromApi v2SessionData, err error) {
+	var sessionDict map[string]interface{}
+
+	sessionDict, err = getV2SessionApi(params, sessionData)
+	if err != nil {
+		return
+	}
+	sessionDataFromApi, err = parseV2SessionData(sessionDict)
+	if err != nil {
+		return
+	}
+	if !sessionDataFromApi.HasExpectedValues(sessionData) {
+		err = fmt.Errorf("Session returned by API query (%s) does not match session requested (%s)",
+			sessionDataFromApi.String(), sessionData.String())
+	}
+	return
+}
+
+// Gets a list of V2 session dictionary objects using listV2SessionsApi,
+// parses those dictionaries into v2SessionData structs.
+// If a tenant was specified, validate that every session belongs to that tenant.
+// Returns that list of structs and error (if any)
+func listV2SessionDatasApi(params *common.Params, tenantName string) (sessionDataList []v2SessionData, err error) {
+	var dictList []map[string]interface{}
+	var sessionData v2SessionData
+
+	dictList, err = listV2SessionsApi(params, tenantName)
+	if err != nil {
+		return
+	}
+	sessionDataList = make([]v2SessionData, 0, len(dictList))
+	for sessionIndex, sessionDict := range dictList {
+		sessionData, err = parseV2SessionData(sessionDict)
+		if err != nil {
+			err = fmt.Errorf("%w; Error parsing session #%d in list", err, sessionIndex)
+			return
+		}
+		// If a tenant was specified, validate that session belongs to the expected tenant
+		if len(tenantName) > 0 && sessionData.Tenant != tenantName {
+			err = fmt.Errorf("Session #%d in the list (%s) does not belong to expected tenant '%s'",
+				sessionIndex, sessionData.String(), tenantName)
+			return
+		}
+		sessionDataList = append(sessionDataList, sessionData)
+	}
+	return
 }
 
 // v2 sessions API tests
-// See comment earlier in the file for a description of this function
-func sessionsV2TestsURI(uri string, params *common.Params) bool {
-	// test #1, list sessions
-	common.Infof("GET %s test scenario", uri)
-	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
-	if err != nil {
-		common.Error(err)
-		return false
-	}
+// See comment earlier in the file for a general description of this function
+//
+// The v2 API version of this function has had further improvements made in order to test good-path multitenancy
+// queries. Specifically, this function now does the following (all using API calls)
+// 1. API query to list all BOS v2 sessions (no tenant name specified)
+// 2. Parses the result, verifying that it is a JSON list, and verifying that each item in that list:
+//    a. Is a JSON dictionary
+//    b. Has a "name" field which maps to a non-0-length string
+//    c. Either has no "tenant" field or has a "tenant" field that maps to a (possibly 0-length) string
+// 3. If the list is empty, then pick a random tenant name (possibly not one which exists on the system)
+//    and issue a query for all BOS sessions belonging to that tenant. Verify that the resulting list is empty.
+// 4. If the list from #1 is not empty, but no sessions belong to a tenant, then do #3.
+// 5. If the list from #1 is not empty and has sessions owned by a tenant, then pick one such tenant, pick above
+//    session owned by that tenant, and also count how many total sessions are owned by that tenant.
+//    a. Query for all BOS sessions belonging to that tenant and verify that we get the same total number. Also
+//       perform the same validation steps as in #2, and validate that every returned session belongs to the specified tenant.
+//    b. Query for the specific BOS session belonging to that tenant and verify that it can be retrieved.
+// 6. If the list from #1 is not empty and has at least one session that is not owned by a tenant, then pick such
+//    a session, query BOS for that specific session, and verify that it can be retrieved.
 
-	// BOS v2: Decode JSON into a list
-	sessionList, err := common.DecodeJSONIntoList(resp.Body())
+// Several of these checks could fail if BOS sessions are being created or deleted while this test is running.
+// While an administrator may be unlikely to choose to create or delete BOS sessions while running this test,
+// the BOS operator responsible for cleaning up old sessions could delete a session during test execution and cause
+// it to fail. For now, this will be a documented limitation of the test, with the recommendation to re-run just
+// the BOS health check in the case that certain failures are seen. Eventually the test could be improved to automatically
+// retry the relevant checks a limited number of times, to reduce the likelihood of false failures.
+
+func sessionsV2TestsURI(params *common.Params, tenantList []string) bool {
+	var tenantedSessionData, untenantedSessionData v2SessionData
+	var tenantedSessionCount int
+	var err error
+	var sessionDataList []v2SessionData
+
+	// test #1, list sessions
+	sessionDataList, err = listV2SessionDatasApi(params, "")
 	if err != nil {
 		common.Error(err)
 		return false
-	} else if len(sessionList) == 0 {
-		common.Infof("skipping test GET %s/{session_id}", uri)
+	} else if len(sessionDataList) == 0 {
+		common.Infof("skipping test GET %s/{session_id}", bosV2SessionsUri)
 		common.Infof("results from previous test is []")
+
+		// However, we can still try to list all of the sessions with a tenant name specified.
+		// Since no sessions were found from the un-tenanted query, we expect none to be found once a tenant
+		// is specified
+		tenant := getAnyTenant(tenantList)
+		sessionDataList, err = listV2SessionDatasApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			return false
+		}
+
+		// Validate that this list is empty
+		if len(sessionDataList) > 0 {
+			common.Errorf("Listing of all sessions empty, but found %d when listing sessions for tenant '%s'",
+				len(sessionDataList), tenant)
+			return false
+		}
+		common.Infof("Session list is still empty, as expected")
 		return true
 	}
 
-	// Take the first session listed. It should be a dictionary object.
-	sessionObject := sessionList[0]
-	session, ok := sessionObject.(map[string]interface{})
-	if !ok {
-		common.Errorf("First BOS session listed is not a dictionary object: %v", sessionObject)
-		return false
+	// From the session ID list, we want to identify:
+	// * One session that has no tenant (untenantedSessionData)
+	// * One session that belongs to a tenant (tenantedSessionData), and a count (tenantedSessionCount)
+	//   of how many sessions in total have that same tenant
+	for sessionIndex, sessionData := range sessionDataList {
+		common.Debugf("Parsing session #%d in the session list (%s)", sessionIndex, sessionData.String())
+		if len(sessionData.Tenant) == 0 {
+			// This session has no tenant
+			if untenantedSessionData.IsNil() {
+				// This is the first session we have encountered that has no tenant field,
+				// so take note of it
+				untenantedSessionData = sessionData
+				common.Infof("Found BOS v2 session #%d (%s)", sessionIndex, untenantedSessionData.String())
+			}
+			continue
+		}
+		// This session is owned by a tenant.
+		if tenantedSessionData.IsNil() {
+			// This is the first session we've found that is owned by a tenant, so remember it,
+			// and note that we have found 1 session belonging to this tenant so far
+			tenantedSessionData = sessionData
+			tenantedSessionCount = 1
+			common.Infof("Found BOS v2 session #%d (%s)", sessionIndex, tenantedSessionData.String())
+			continue
+		}
+		// We have already found a session belonging to a tenant. If it is the tenant we found first,
+		// increment our session count
+		if sessionData.Tenant == tenantedSessionData.Tenant {
+			tenantedSessionCount += 1
+		}
 	}
 
-	common.Debugf("Getting 'name' field BOS session: %v", session)
-	sessionId, err := common.GetStringFieldFromMapObject("name", session)
+	passed := true
+
+	if untenantedSessionData.IsNil() {
+		common.Infof("skipping test GET %s/{session_id} with no tenant specified, because all BOS v2 sessions are owned by tenants",
+			bosV2SessionsUri)
+	} else {
+		// test: describe session using the untenanted session name we found earlier
+		_, err = getV2SessionDataApi(params, untenantedSessionData)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		}
+	}
+
+	if tenantedSessionData.IsNil() {
+		common.Infof("No BOS v2 sessions found belonging to any tenants")
+
+		tenant := getAnyTenant(tenantList)
+		sessionDataList, err = listV2SessionDatasApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		} else {
+			// Validate that this list is empty
+			if len(sessionDataList) > 0 {
+				common.Errorf("Listing all sessions found none owned by tenants, but found %d when listing sessions for tenant '%s'",
+					len(sessionDataList), tenant)
+				passed = false
+			}
+			common.Infof("List of sessions belonging to tenant '%s' is empty, as expected", tenant)
+		}
+		return passed
+	}
+	common.Infof("Counted %d BOS v2 sessions belonging to tenant '%s'", tenantedSessionCount, tenantedSessionData.Tenant)
+	sessionDataList, err = listV2SessionDatasApi(params, tenantedSessionData.Tenant)
+	if err != nil {
+		common.Error(err)
+		passed = false
+	} else {
+		// Validate that this list is expected length
+		if len(sessionDataList) != tenantedSessionCount {
+			common.Errorf("Listing all sessions found %d owned by tenant '%s', but found %d when listing sessions for that tenant",
+				tenantedSessionCount, tenantedSessionData.Tenant, len(sessionDataList))
+			passed = false
+		}
+		common.Infof("List of sessions belonging to tenant '%s' is the expected length", tenantedSessionData.Tenant)
+	}
+
+	// test: describe session using the session name we found owned by a tenant in the earlier loop
+	_, err = getV2SessionDataApi(params, tenantedSessionData)
 	if err != nil {
 		common.Error(err)
 		return false
 	}
-	common.Infof("Found BOS v2 session with name '%s'", sessionId)
 
-	// test #2: describe session
-	uri += "/" + sessionId
-	resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
-	if err != nil {
-		common.Error(err)
-		return false
-	} else if !ValidateV2Session(resp.Body(), sessionId) {
-		return false
-	}
-
-	return true
+	return passed
 }
 
 // v1 sessions CLI tests
@@ -215,15 +497,47 @@ func sessionsV1TestsCLICommand(cmdArgs ...string) bool {
 	}
 
 	// A session id is available
-	sessionId := stringList[0]
-	common.Infof("Found BOS v1 session with ID '%s'", sessionId)
+	sessionData := stringList[0]
+	common.Infof("Found BOS v1 session with ID '%s'", sessionData)
 
 	// test #2, describe session with session_id
-	if !basicCLIDescribeVerifyStringMapTest(sessionId, cmdArgs...) {
+	if !basicCLIDescribeVerifyStringMapTest(sessionData, cmdArgs...) {
 		return false
 	}
 
 	return true
+}
+
+// Given a response object (as an array of bytes), validate that:
+// 1. It resolves to a JSON dictonary
+// 2. That dictionary has a "name" field
+// 3. The "name" field of that dictionary has a value which matches our expectedName string
+//
+// Return true if all of the above is true. Otherwise, log an appropriate error and return false.
+func ValidateV2Session(mapCmdOut []byte, expectedId v2SessionData) bool {
+	common.Infof("Validating that BOS v2 session has expected values for name and tenant")
+
+	// This function should always receive a non-0-length expected name for the session
+	if len(expectedId.Name) == 0 {
+		common.Errorf("Programming logic error: ValidateV2Session function received 0-length string for expected name")
+		return false
+	}
+
+	// Should be a dictionary object mapping strings to values
+	common.Debugf("Parsing session as a dictionary")
+	sessionDict, err := common.DecodeJSONIntoStringMap(mapCmdOut)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	sessionData, err := parseV2SessionData(sessionDict)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	return sessionData.HasExpectedValues(expectedId)
 }
 
 // v2 sessions CLI tests
@@ -255,18 +569,18 @@ func sessionsV2TestsCLICommand(cmdArgs ...string) bool {
 	}
 
 	common.Debugf("Getting 'name' field BOS session: %v", session)
-	sessionId, err := common.GetStringFieldFromMapObject("name", session)
+	sessionData, err := common.GetStringFieldFromMapObject("name", session)
 	if err != nil {
 		common.Error(err)
 		return false
 	}
-	common.Infof("Found BOS v2 session with name '%s'", sessionId)
+	common.Infof("Found BOS v2 session with name '%s'", sessionData)
 
 	// test #2, describe session with session_id
-	cmdOut = runBosCLIDescribe(sessionId, cmdArgs...)
+	cmdOut = runBosCLIDescribe(sessionData, cmdArgs...)
 	if cmdOut == nil {
 		return false
-	} else if !ValidateV2Session(cmdOut, sessionId) {
+	} else if !ValidateV2Session(cmdOut, v2SessionData{Name: sessionData, Tenant: ""}) {
 		return false
 	}
 

--- a/cmsdev/internal/test/bos/bos_session_tests.go
+++ b/cmsdev/internal/test/bos/bos_session_tests.go
@@ -1,0 +1,356 @@
+// MIT License
+//
+// (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+package bos
+
+/*
+ * bos_session_tests.go
+ *
+ * BOS session tests
+ *
+ */
+
+import (
+	"net/http"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"strings"
+)
+
+// The sessionsV1TestsURI, sessionsV2TestsURI, sessionsV1TestsCLICommand, and sessionsV2TestsCLICommand functions
+// define the API and CLI versions of the BOS v1 and v2 session subtests.
+// They all do essentially the same thing, although the v2 API test has some enhancements described later in the file.
+// 1. List all sessions
+// 2. Verify that this succeeds and returns something of the right general form (for v1, this is expected to be a list of strings,
+//    whereas for v2 this should be a list of dictionary objects)
+// 3. If the list returned is empty, then the subtest is over. Otherwise, select the first element of the list. (If bosV2, extract the "name" field of that element).
+// 4. Do a GET/describe on that particular session
+// 5. Verify that this succeeds and returns something of the right general form. For BOS v2, also verify that it has the expected name
+//    (in v1, the session ID is not in the returned object)
+
+func sessionsTestsAPI(params *common.Params, tenantList []string) (passed bool) {
+	passed = true
+
+	// v1 sessions
+	if !sessionsV1TestsURI(bosV1SessionsUri, params) {
+		passed = false
+	}
+
+	// v2 sessions
+	if !sessionsV2TestsURI(params, tenantList) {
+		passed = false
+	}
+
+	return
+}
+
+func sessionsTestsCLI() (passed bool) {
+	passed = true
+
+	// v1 sessions
+	if !sessionsV1TestsCLICommand("v1", bosV1SessionsCLI) {
+		passed = false
+	}
+
+	// v2 sessions
+	if !sessionsV2TestsCLICommand("v2", bosV2SessionsCLI) {
+		passed = false
+	}
+
+	// default (v2) sessions
+	if !sessionsV2TestsCLICommand(bosDefaultSessionsCLI) {
+		passed = false
+	}
+
+	return
+}
+
+////////////////////////////////////////////////////////////////////////////
+// v1 tests
+////////////////////////////////////////////////////////////////////////////
+
+// v1 sessions API tests
+// See comment at the top of the file for a description of this function
+func sessionsV1TestsURI(uri string, params *common.Params) bool {
+	// test #1, list session
+	common.Infof("GET %s test scenario", uri)
+	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// BOS v1: Validate that at least we can decode the JSON into a list of strings
+	stringList, err := common.DecodeJSONIntoStringList(resp.Body())
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(stringList) == 0 {
+		common.Infof("skipping test GET %s/{session_id}", uri)
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// a session_id is available
+	sessionData := stringList[0]
+	common.Infof("Found BOS v1 session with ID '%s'", sessionData)
+
+	// test #2, describe session with session_id
+	uri += "/" + sessionData
+	if !basicGetUriVerifyStringMapTest(uri, params) {
+		return false
+	}
+
+	return true
+}
+
+// v1 sessions CLI tests
+// See comment at the top of the file for a description of this function
+func sessionsV1TestsCLICommand(cmdArgs ...string) bool {
+	// test #1, list sessions
+	cmdOut := runBosCLIList(cmdArgs...)
+	if cmdOut == nil {
+		return false
+	}
+
+	// BOS v1: Validate that at least we can decode the JSON into a list of strings
+	stringList, err := common.DecodeJSONIntoStringList(cmdOut)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	// Grab the first session ID
+	if len(stringList) == 0 {
+		common.Infof("skipping test CLI describe {session_id}")
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// A session id is available
+	sessionData := stringList[0]
+	common.Infof("Found BOS v1 session with ID '%s'", sessionData)
+
+	// test #2, describe session with session_id
+	if !basicCLIDescribeVerifyStringMapTest(sessionData, cmdArgs...) {
+		return false
+	}
+
+	return true
+}
+
+////////////////////////////////////////////////////////////////////////////
+// v2 tests
+////////////////////////////////////////////////////////////////////////////
+
+// v2 sessions API tests
+// See comment at the top of the file for a general description of this function
+//
+// The v2 API version of this function has had further improvements made in order to test good-path multitenancy
+// queries. Specifically, this function now does the following (all using API calls)
+// 1. API query to list all BOS v2 sessions (no tenant name specified)
+// 2. Parses the result, verifying that it is a JSON list, and verifying that each item in that list:
+//    a. Is a JSON dictionary
+//    b. Has a "name" field which maps to a non-0-length string
+//    c. Either has no "tenant" field or has a "tenant" field that maps to a (possibly 0-length) string
+// 3. If the list is empty, then pick a random tenant name (possibly not one which exists on the system)
+//    and issue a query for all BOS sessions belonging to that tenant. Verify that the resulting list is empty.
+// 4. If the list from #1 is not empty, but no sessions belong to a tenant, then do #3.
+// 5. If the list from #1 is not empty and has sessions owned by a tenant, then pick one such tenant, pick above
+//    session owned by that tenant, and also count how many total sessions are owned by that tenant.
+//    a. Query for all BOS sessions belonging to that tenant and verify that we get the same total number. Also
+//       perform the same validation steps as in #2, and validate that every returned session belongs to the specified tenant.
+//    b. Query for the specific BOS session belonging to that tenant and verify that it can be retrieved.
+// 6. If the list from #1 is not empty and has at least one session that is not owned by a tenant, then pick such
+//    a session, query BOS for that specific session, and verify that it can be retrieved.
+
+// Several of these checks could fail if BOS sessions are being created or deleted while this test is running.
+// While an administrator may be unlikely to choose to create or delete BOS sessions while running this test,
+// the BOS operator responsible for cleaning up old sessions could delete a session during test execution and cause
+// it to fail. For now, this will be a documented limitation of the test, with the recommendation to re-run just
+// the BOS health check in the case that certain failures are seen. Eventually the test could be improved to automatically
+// retry the relevant checks a limited number of times, to reduce the likelihood of false failures.
+
+func sessionsV2TestsURI(params *common.Params, tenantList []string) bool {
+	var tenantedSessionData, untenantedSessionData v2SessionData
+	var tenantedSessionCount int
+	var err error
+	var sessionDataList []v2SessionData
+
+	// test #1, list sessions with no tenant specified
+	sessionDataList, err = listV2SessionDataApi(params, "")
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(sessionDataList) == 0 {
+		common.Infof("skipping test GET %s/{session_id}", bosV2SessionsUri)
+		common.Infof("results from previous test is []")
+
+		// However, we can still try to list all of the sessions with a tenant name specified.
+		// Since no sessions were found from the un-tenanted query, we expect none to be found once a tenant
+		// is specified
+		tenant := getAnyTenant(tenantList)
+		sessionDataList, err = listV2SessionDataApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			return false
+		}
+
+		// Validate that this list is empty
+		if len(sessionDataList) > 0 {
+			common.Errorf("Listing of all sessions empty, but found %d when listing sessions for tenant '%s'",
+				len(sessionDataList), tenant)
+			return false
+		}
+		common.Infof("Session list is still empty, as expected")
+		return true
+	}
+
+	// From the session ID list, we want to identify:
+	// * One session that has no tenant (untenantedSessionData)
+	// * One session that belongs to a tenant (tenantedSessionData), and a count (tenantedSessionCount)
+	//   of how many sessions in total have that same tenant
+	for sessionIndex, sessionData := range sessionDataList {
+		common.Debugf("Parsing session #%d in the session list (%s)", sessionIndex, sessionData.String())
+		if len(sessionData.Tenant) == 0 {
+			// This session has no tenant
+			if untenantedSessionData.IsNil() {
+				// This is the first session we have encountered that has no tenant field,
+				// so take note of it
+				untenantedSessionData = sessionData
+				common.Infof("Found BOS v2 session #%d (%s)", sessionIndex, untenantedSessionData.String())
+			}
+			continue
+		}
+		// This session is owned by a tenant.
+		if tenantedSessionData.IsNil() {
+			// This is the first session we've found that is owned by a tenant, so remember it,
+			// and note that we have found 1 session belonging to this tenant so far
+			tenantedSessionData = sessionData
+			tenantedSessionCount = 1
+			common.Infof("Found BOS v2 session #%d (%s)", sessionIndex, tenantedSessionData.String())
+			continue
+		}
+		// We have already found a session belonging to a tenant. If it is the tenant we found first,
+		// increment our session count
+		if sessionData.Tenant == tenantedSessionData.Tenant {
+			tenantedSessionCount += 1
+		}
+	}
+
+	passed := true
+
+	if untenantedSessionData.IsNil() {
+		common.Infof("skipping test GET %s/{session_id} with no tenant specified, because all BOS v2 sessions are owned by tenants",
+			bosV2SessionsUri)
+	} else {
+		// test: describe session using the untenanted session name we found earlier
+		_, err = getV2SessionDataApi(params, untenantedSessionData)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		}
+	}
+
+	if tenantedSessionData.IsNil() {
+		common.Infof("No BOS v2 sessions found belonging to any tenants")
+
+		tenant := getAnyTenant(tenantList)
+		sessionDataList, err = listV2SessionDataApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		} else {
+			// Validate that this list is empty
+			if len(sessionDataList) > 0 {
+				common.Errorf("Listing all sessions found none owned by tenants, but found %d when listing sessions for tenant '%s'",
+					len(sessionDataList), tenant)
+				passed = false
+			}
+			common.Infof("List of sessions belonging to tenant '%s' is empty, as expected", tenant)
+		}
+		return passed
+	}
+	common.Infof("Counted %d BOS v2 sessions belonging to tenant '%s'", tenantedSessionCount, tenantedSessionData.Tenant)
+	sessionDataList, err = listV2SessionDataApi(params, tenantedSessionData.Tenant)
+	if err != nil {
+		common.Error(err)
+		passed = false
+	} else {
+		// Validate that this list is expected length
+		if len(sessionDataList) != tenantedSessionCount {
+			common.Errorf("Listing all sessions found %d owned by tenant '%s', but found %d when listing sessions for that tenant",
+				tenantedSessionCount, tenantedSessionData.Tenant, len(sessionDataList))
+			passed = false
+		}
+		common.Infof("List of sessions belonging to tenant '%s' is the expected length", tenantedSessionData.Tenant)
+	}
+
+	// test: describe session using the session name we found owned by a tenant in the earlier loop
+	_, err = getV2SessionDataApi(params, tenantedSessionData)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	return passed
+}
+
+// v2 sessions CLI tests
+// See comment at the top of the file for a description of this function
+func sessionsV2TestsCLICommand(cmdArgs ...string) bool {
+	var untenantedSessionData v2SessionData
+
+	// test #1, list sessions
+	sessionDataList, passed := listV2SessionDataCli(cmdArgs...)
+	if !passed {
+		return false
+	}
+	if len(sessionDataList) == 0 {
+		common.Infof("skipping test CLI %s describe {session_id}", strings.Join(cmdArgs, " "))
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// From the session ID list, we want to identify:
+	// * One session that has no tenant (untenantedSessionData)
+	for sessionIndex, sessionData := range sessionDataList {
+		common.Debugf("Parsing session #%d in the session list (%s)", sessionIndex, sessionData.String())
+		if len(sessionData.Tenant) == 0 {
+			// This session has no tenant
+			untenantedSessionData = sessionData
+			common.Infof("Found BOS v2 session #%d (%s)", sessionIndex, untenantedSessionData.String())
+			break
+		}
+	}
+
+	if untenantedSessionData.IsNil() {
+		common.Infof("skipping test CLI %s describe {session_id} with no tenant specified, because all BOS v2 sessions are owned by tenants",
+			strings.Join(cmdArgs, " "))
+		return true
+	}
+
+	// test #2, describe session with session_id
+	cmdOut := runBosCLIDescribe(untenantedSessionData.Name, cmdArgs...)
+	if cmdOut == nil {
+		return false
+	}
+	return ValidateV2Session(cmdOut, untenantedSessionData)
+}

--- a/cmsdev/internal/test/bos/bos_sessiontemplate.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate.go
@@ -29,7 +29,11 @@ package bos
  */
 
 import (
+	"errors"
+	"fmt"
+	resty "gopkg.in/resty.v1"
 	"net/http"
+	"reflect"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 )
 
@@ -47,6 +51,106 @@ const bosV1SessionTemplateTemplateCLI = "sessiontemplatetemplate"
 const bosV2SessionTemplateTemplateCLI = "sessiontemplatetemplate"
 const bosDefaultSessionTemplateTemplateCLI = bosV2SessionTemplateTemplateCLI
 
+// A BOS v2 session template is uniquely identified by its name and tenant. The tenant may null, blank,
+// or, equivalently, not present in the actual record. In all such cases, the
+// following struct uses an empty string value for Tenant.
+type v2TemplateData struct {
+	Name, Tenant string
+}
+
+// Returns true if the Name field of the object is "", false otherwise
+func (templateData v2TemplateData) IsNil() bool {
+	return templateData.Name == ""
+}
+
+// Returns a string representation of the object
+func (templateData v2TemplateData) String() string {
+	if len(templateData.Tenant) > 0 {
+		return fmt.Sprintf("name: '%s', tenant: '%s'", templateData.Name, templateData.Tenant)
+	}
+	return fmt.Sprintf("name: '%s', no tenant", templateData.Name)
+}
+
+// Compares two objects. Returns true if both fields match, false otherwise. If false,
+// appropriate errors are also logged noting the discrepancies
+func (templateData v2TemplateData) HasExpectedValues(expectedTemplateData v2TemplateData) (passed bool) {
+	// Let's be optimistic and assume that they will match
+	passed = true
+
+	// Validate that name fields match
+	if templateData.Name != expectedTemplateData.Name {
+		common.Errorf("BOS session template name '%s' does not match expected name '%s'", templateData.Name, expectedTemplateData.Name)
+		passed = false
+	} else {
+		common.Debugf("BOS session template name '%s' matches expected value", templateData.Name)
+	}
+
+	// Validate the tenant name
+	if templateData.Tenant == expectedTemplateData.Tenant {
+		if len(templateData.Tenant) == 0 {
+			common.Debugf("Session template does not belong to a tenant, which matches expectations")
+		} else {
+			common.Debugf("Session template belongs to the expected tenant")
+		}
+		return
+	}
+	passed = false
+	if len(templateData.Tenant) == 0 {
+		common.Errorf("Session template does not belong to a tenant, but it should belong to '%s'", expectedTemplateData.Tenant)
+	} else {
+		common.Errorf("Session template belongs to tenant '%s', but it should not belong to any tenant", templateData.Tenant)
+	}
+	return
+}
+
+// Takes as input a mapping from strings to arbitrary objects.
+// Parses it to extract the values of the 'name' and 'tenant' fields (although the
+// latter is allowed to be absent). Validates that 'name' (and 'tenant', if present and non-null)
+// have string values and that 'name' is non-0 length. Returns a v2TemplateData object
+// populated from those fields. Returns an error with any problems encountered.
+func parseV2TemplateData(sessionTemplateDict map[string]interface{}) (templateData v2TemplateData, totalErr error) {
+	var err error
+	var fieldFound, fieldIsString bool
+	var sessionTemplateTenantField interface{}
+
+	common.Debugf("Getting name of session template")
+	templateData.Name, err = common.GetStringFieldFromMapObject("name", sessionTemplateDict)
+	if err != nil {
+		err = fmt.Errorf("%w; Error getting 'name' field of BOS session template", err)
+	} else if len(templateData.Name) == 0 {
+		err = fmt.Errorf("BOS session template has a 0-length name")
+	} else {
+		common.Debugf("Name of session template is '%s'", templateData.Name)
+	}
+	totalErr = errors.Join(totalErr, err)
+
+	common.Debugf("Checking for 'tenant' field of session template '%s'", templateData.Name)
+	sessionTemplateTenantField, fieldFound = sessionTemplateDict["tenant"]
+	if !fieldFound {
+		// This session template has no tenant field, which is equivalent to a 0-length string tenant field
+		templateData.Tenant = ""
+		common.Debugf("Session template '%s' has no 'tenant' field", templateData.Name)
+		return
+	}
+	if sessionTemplateTenantField == nil {
+		// This session template has null-value tenant field, which is equivalent to a 0-length string tenant field
+		templateData.Tenant = ""
+		common.Debugf("Session template '%s' has null 'tenant' field", templateData.Name)
+		return
+	}
+
+	// If it is present and non-null, it should be a string value
+	templateData.Tenant, fieldIsString = sessionTemplateTenantField.(string)
+	if !fieldIsString {
+		// tenant field has non-string value
+		err = fmt.Errorf("Session template '%s' has a non-null 'tenant' field but its value is type %s, not string",
+			templateData.Name, reflect.TypeOf(sessionTemplateTenantField).String())
+		totalErr = errors.Join(totalErr, err)
+	}
+	common.Debugf("Session template: %s", templateData.String())
+	return
+}
+
 // The sessionTemplatesTestsURI and sessionTemplatesTestsCLICommand functions define the API and CLI versions of the BOS session template subtests.
 // They both do the same thing:
 // 1. List all session templates
@@ -55,7 +159,7 @@ const bosDefaultSessionTemplateTemplateCLI = bosV2SessionTemplateTemplateCLI
 // 4. Do a GET/describe on that particular session template
 // 5. Verify that this succeeds and returns something of the right general form
 
-func sessionTemplatesTestsAPI(params *common.Params) (passed bool) {
+func sessionTemplatesTestsAPI(params *common.Params, tenantList []string) (passed bool) {
 	passed = true
 
 	// session template template API tests
@@ -75,12 +179,12 @@ func sessionTemplatesTestsAPI(params *common.Params) (passed bool) {
 	// session template API tests
 
 	// v1
-	if !sessionTemplatesTestsURI(bosV1SessionTemplatesUri, params) {
+	if !v1SessionTemplatesTestsURI(bosV1SessionTemplatesUri, params) {
 		passed = false
 	}
 
 	// v2
-	if !sessionTemplatesTestsURI(bosV2SessionTemplatesUri, params) {
+	if !v2SessionTemplatesTestsURI(params, tenantList) {
 		passed = false
 	}
 
@@ -128,13 +232,257 @@ func sessionTemplatesTestsCLI() (passed bool) {
 	return
 }
 
+// Performs an API query to get a particular BOS v2 session template (possibly belonging to a tenant)
+// Parses the result to convert it to a dictionary with string keys
+// Returns the result and error (if any)
+func getV2TemplateApi(params *common.Params, templateData v2TemplateData) (sessionTemplateDict map[string]interface{}, err error) {
+	var resp *resty.Response
+	uri := bosV2SessionTemplatesUri + "/" + templateData.Name
+	if len(templateData.Tenant) == 0 {
+		common.Infof("GET %s test scenario", uri)
+		resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
+	} else {
+		common.Infof("GET %s (tenant: %s) test scenario", uri, templateData.Tenant)
+		resp, err = bosTenantRestfulVerifyStatus("GET", uri, templateData.Tenant, params, http.StatusOK)
+	}
+	if err != nil {
+		return
+	}
+	// Decode JSON into a string map
+	sessionTemplateDict, err = common.DecodeJSONIntoStringMap(resp.Body())
+	return
+}
+
+// Performs an API query to list BOS v2 sessions (possibly with a tenant specified)
+// Parses the result to convert it to a list of dictionaries with string keys
+// Returns the result and error (if any)
+func listV2SessionTemplatesApi(params *common.Params, tenantName string) (dictList []map[string]interface{}, err error) {
+	var resp *resty.Response
+	if len(tenantName) == 0 {
+		common.Infof("GET %s test scenario", bosV2SessionTemplatesUri)
+		resp, err = bosRestfulVerifyStatus("GET", bosV2SessionTemplatesUri, params, http.StatusOK)
+	} else {
+		common.Infof("GET %s (tenant: %s) test scenario", bosV2SessionTemplatesUri, tenantName)
+		resp, err = bosTenantRestfulVerifyStatus("GET", bosV2SessionTemplatesUri, tenantName, params, http.StatusOK)
+	}
+	if err != nil {
+		return
+	}
+	// Decode JSON into a list of string maps
+	dictList, err = common.DecodeJSONIntoStringMapList(resp.Body())
+	return
+}
+
+// Get a particular BOS v2 session template (possibly belonging to a tenant) using getV2TemplateApi,
+// parses that dictionaries into a v2TemplateData struct.
+// Validates that it matches the expected session template name and (if any) tenant name.
+// Returns that struct and error (if any)
+func getV2TemplateDataApi(params *common.Params, templateData v2TemplateData) (templateDataFromApi v2TemplateData, err error) {
+	var sessionTemplateDict map[string]interface{}
+
+	sessionTemplateDict, err = getV2TemplateApi(params, templateData)
+	if err != nil {
+		return
+	}
+	templateDataFromApi, err = parseV2TemplateData(sessionTemplateDict)
+	if err != nil {
+		return
+	}
+	if !templateDataFromApi.HasExpectedValues(templateData) {
+		err = fmt.Errorf("SessionTemplate returned by API query (%s) does not match session template requested (%s)",
+			templateDataFromApi.String(), templateData.String())
+	}
+	return
+}
+
+// Gets a list of V2 session template dictionary objects using listV2SessionTemplatesApi,
+// parses those dictionaries into v2TemplateData structs.
+// If a tenant was specified, validate that every session template belongs to that tenant.
+// Returns that list of structs and error (if any)
+func listV2TemplateDatasApi(params *common.Params, tenantName string) (templateDataList []v2TemplateData, err error) {
+	var dictList []map[string]interface{}
+	var templateData v2TemplateData
+
+	dictList, err = listV2SessionTemplatesApi(params, tenantName)
+	if err != nil {
+		return
+	}
+	templateDataList = make([]v2TemplateData, 0, len(dictList))
+	for sessionTemplateIndex, sessionTemplateDict := range dictList {
+		templateData, err = parseV2TemplateData(sessionTemplateDict)
+		if err != nil {
+			err = fmt.Errorf("%w; Error parsing session template #%d in list", err, sessionTemplateIndex)
+			return
+		}
+		// If a tenant was specified, validate that session template belongs to the expected tenant
+		if len(tenantName) > 0 && templateData.Tenant != tenantName {
+			err = fmt.Errorf("SessionTemplate #%d in the list (%s) does not belong to expected tenant '%s'",
+				sessionTemplateIndex, templateData.String(), tenantName)
+			return
+		}
+		templateDataList = append(templateDataList, templateData)
+	}
+	return
+}
+
+// v2 session templates API tests
+// See comment earlier in the file for a general description of this function
+//
+// The v2 API version of this function has had further improvements made in order to test good-path multitenancy
+// queries. Specifically, this function now does the following (all using API calls)
+// 1. API query to list all BOS v2 session templates (no tenant name specified)
+// 2. Parses the result, verifying that it is a JSON list, and verifying that each item in that list:
+//    a. Is a JSON dictionary
+//    b. Has a "name" field which maps to a non-0-length string
+//    c. Either has no "tenant" field or has a "tenant" field that maps to a (possibly 0-length) string
+// 3. If the list is empty, then pick a random tenant name (possibly not one which exists on the system)
+//    and issue a query for all BOS session templates belonging to that tenant. Verify that the resulting list is empty.
+// 4. If the list from #1 is not empty, but no session templates belong to a tenant, then do #3.
+// 5. If the list from #1 is not empty and has session templates owned by a tenant, then pick one such tenant, pick above
+//    session template owned by that tenant, and also count how many total session templates are owned by that tenant.
+//    a. Query for all BOS session templates belonging to that tenant and verify that we get the same total number. Also
+//       perform the same validation steps as in #2, and validate that every returned session template belongs to the specified tenant.
+//    b. Query for the specific BOS session template belonging to that tenant and verify that it can be retrieved.
+// 6. If the list from #1 is not empty and has at least one session template that is not owned by a tenant, then pick such
+//    a session template, query BOS for that specific session template, and verify that it can be retrieved.
+
+// Several of these checks could fail if BOS session templates are being created or deleted while this test is running.
+// For now, this will be a documented limitation of the test, with the recommendation to re-run just
+// the BOS health check in the case that certain failures are seen. Eventually the test could be improved to automatically
+// retry the relevant checks a limited number of times, to reduce the likelihood of false failures.
+
+func v2SessionTemplatesTestsURI(params *common.Params, tenantList []string) bool {
+	var tenantedTemplateData, untenantedTemplateData v2TemplateData
+	var tenantedTemplateCount int
+	var err error
+	var templateDataList []v2TemplateData
+
+	// test #1, list sessions
+	templateDataList, err = listV2TemplateDatasApi(params, "")
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(templateDataList) == 0 {
+		common.Infof("skipping test GET %s/{session_template_id}", bosV2SessionTemplatesUri)
+		common.Infof("results from previous test is []")
+
+		// However, we can still try to list all of the session templates with a tenant name specified.
+		// Since no session templates were found from the un-tenanted query, we expect none to be found once a tenant
+		// is specified
+		tenant := getAnyTenant(tenantList)
+		templateDataList, err = listV2TemplateDatasApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			return false
+		}
+
+		// Validate that this list is empty
+		if len(templateDataList) > 0 {
+			common.Errorf("Listing of all session templates empty, but found %d when listing session templates for tenant '%s'",
+				len(templateDataList), tenant)
+			return false
+		}
+		common.Infof("Session template list is still empty, as expected")
+		return true
+	}
+
+	// From the session template ID list, we want to identify:
+	// * One session template that has no tenant (untenantedTemplateData)
+	// * One session template that belongs to a tenant (tenantedTemplateData), and a count (tenantedTemplateCount)
+	//   of how many session templates in total have that same tenant
+	for sessionTemplateIndex, TemplateData := range templateDataList {
+		common.Debugf("Parsing session #%d in the session list (%s)", sessionTemplateIndex, TemplateData.String())
+		if len(TemplateData.Tenant) == 0 {
+			// This session template has no tenant
+			if untenantedTemplateData.IsNil() {
+				// This is the first session template we have encountered that has no tenant field,
+				// so take note of it
+				untenantedTemplateData = TemplateData
+				common.Infof("Found BOS v2 session template #%d (%s)", sessionTemplateIndex, untenantedTemplateData.String())
+			}
+			continue
+		}
+		// This session template is owned by a tenant.
+		if tenantedTemplateData.IsNil() {
+			// This is the first session template we've found that is owned by a tenant, so remember it,
+			// and note that we have found 1 session template belonging to this tenant so far
+			tenantedTemplateData = TemplateData
+			tenantedTemplateCount = 1
+			common.Infof("Found BOS v2 session template #%d (%s)", sessionTemplateIndex, tenantedTemplateData.String())
+			continue
+		}
+		// We have already found a session template belonging to a tenant. If it is the tenant we found first,
+		// increment our session count
+		if TemplateData.Tenant == tenantedTemplateData.Tenant {
+			tenantedTemplateCount += 1
+		}
+	}
+
+	passed := true
+
+	if untenantedTemplateData.IsNil() {
+		common.Infof("skipping test GET %s/{session_template_id} with no tenant specified, because all BOS v2 session templates are owned by tenants",
+			bosV2SessionTemplatesUri)
+	} else {
+		// test: describe session template using the untenanted session template name we found earlier
+		_, err = getV2TemplateDataApi(params, untenantedTemplateData)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		}
+	}
+
+	if tenantedTemplateData.IsNil() {
+		common.Infof("No BOS v2 session templates found belonging to any tenants")
+
+		tenant := getAnyTenant(tenantList)
+		templateDataList, err = listV2TemplateDatasApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		} else {
+			// Validate that this list is empty
+			if len(templateDataList) > 0 {
+				common.Errorf("Listing all session templates found none owned by tenants, but found %d when listing session templates for tenant '%s'",
+					len(templateDataList), tenant)
+				passed = false
+			}
+			common.Infof("List of session templates belonging to tenant '%s' is empty, as expected", tenant)
+		}
+		return passed
+	}
+	common.Infof("Counted %d BOS v2 session templates belonging to tenant '%s'", tenantedTemplateCount, tenantedTemplateData.Tenant)
+	templateDataList, err = listV2TemplateDatasApi(params, tenantedTemplateData.Tenant)
+	if err != nil {
+		common.Error(err)
+		passed = false
+	} else {
+		// Validate that this list is expected length
+		if len(templateDataList) != tenantedTemplateCount {
+			common.Errorf("Listing all session templates found %d owned by tenant '%s', but found %d when listing session templates for that tenant",
+				tenantedTemplateCount, tenantedTemplateData.Tenant, len(templateDataList))
+			passed = false
+		}
+		common.Infof("List of session templates belonging to tenant '%s' is the expected length", tenantedTemplateData.Tenant)
+	}
+
+	// test: describe session template using the session template name we found owned by a tenant in the earlier loop
+	_, err = getV2TemplateDataApi(params, tenantedTemplateData)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	return passed
+}
+
 // Given a response object (as an array of bytes), do the following:
 // 1. Verify that it is a JSON list object
 // 2. If the list object is empty, return a blank string.
 // 3. If the list is not empty, verify that its first element is a dictionary.
 // 4. Look up the "name" key in that dictionary, and return its value.
 // If any of the above does not work, return an appropriate error.
-func getFirstSessionTemplateId(listCmdOut []byte) (string, error) {
+func getFirstTemplateData(listCmdOut []byte) (string, error) {
 	return common.GetStringFieldFromFirstItem("name", listCmdOut)
 }
 
@@ -144,7 +492,7 @@ func getFirstSessionTemplateId(listCmdOut []byte) (string, error) {
 // 3. The "name" field of that dictionary has a value which matches our expectedName string
 //
 // Return true if all of the above is true. Otherwise, log an appropriate error and return false.
-func ValidateSessionTemplateId(mapCmdOut []byte, expectedName string) bool {
+func ValidateTemplateData(mapCmdOut []byte, expectedName string) bool {
 	err := common.ValidateStringFieldValue("BOS sessiontemplate", "name", expectedName, mapCmdOut)
 	if err != nil {
 		common.Error(err)
@@ -155,7 +503,7 @@ func ValidateSessionTemplateId(mapCmdOut []byte, expectedName string) bool {
 
 // session templates API tests
 // See comment earlier in the file for a description of this function
-func sessionTemplatesTestsURI(uri string, params *common.Params) bool {
+func v1SessionTemplatesTestsURI(uri string, params *common.Params) bool {
 	// test #1, list session templates
 	common.Infof("GET %s test scenario", uri)
 	resp, err := bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
@@ -165,24 +513,24 @@ func sessionTemplatesTestsURI(uri string, params *common.Params) bool {
 	}
 
 	// use results from previous test, grab the first session template
-	sessionTemplateId, err := getFirstSessionTemplateId(resp.Body())
+	templateData, err := getFirstTemplateData(resp.Body())
 	if err != nil {
 		common.Error(err)
 		return false
-	} else if len(sessionTemplateId) == 0 {
+	} else if len(templateData) == 0 {
 		common.Infof("skipping test GET %s/{session_template_id}", uri)
 		common.Infof("results from previous test is []")
 		return true
 	}
 
 	// a session_template_id is available
-	uri += "/" + sessionTemplateId
+	uri += "/" + templateData
 	common.Infof("GET %s test scenario", uri)
 	resp, err = bosRestfulVerifyStatus("GET", uri, params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
 		return false
-	} else if !ValidateSessionTemplateId(resp.Body(), sessionTemplateId) {
+	} else if !ValidateTemplateData(resp.Body(), templateData) {
 		return false
 	}
 
@@ -199,11 +547,11 @@ func sessionTemplatesTestsCLICommand(cmdArgs ...string) bool {
 	}
 
 	// use results from previous test, grab the first session template
-	sessionTemplateId, err := getFirstSessionTemplateId(cmdOut)
+	templateData, err := getFirstTemplateData(cmdOut)
 	if err != nil {
 		common.Error(err)
 		return false
-	} else if len(sessionTemplateId) == 0 {
+	} else if len(templateData) == 0 {
 		common.Infof("skipping test CLI describe session template {session_template_id}")
 		common.Infof("results from previous test is []")
 		return true
@@ -211,10 +559,10 @@ func sessionTemplatesTestsCLICommand(cmdArgs ...string) bool {
 
 	// a session template id is available
 	// test #2 describe session templates
-	cmdOut = runBosCLIDescribe(sessionTemplateId, cmdArgs...)
+	cmdOut = runBosCLIDescribe(templateData, cmdArgs...)
 	if cmdOut == nil {
 		return false
-	} else if !ValidateSessionTemplateId(cmdOut, sessionTemplateId) {
+	} else if !ValidateTemplateData(cmdOut, templateData) {
 		return false
 	}
 

--- a/cmsdev/internal/test/bos/bos_sessiontemplate_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate_tests.go
@@ -1,0 +1,354 @@
+// MIT License
+//
+// (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+package bos
+
+/*
+ * bos_sessiontemplate_tests.go
+ *
+ * BOS sessiontemplate tests
+ *
+ */
+
+import (
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"strings"
+)
+
+// The sessionTemplatesTestsURI and sessionTemplatesTestsCLICommand functions define the API and CLI versions of the BOS session template subtests.
+// They both basically do the same thing, although the V2 API test has some enhancements described later in the file.
+// 1. List all session templates
+// 2. Verify that this succeeds and returns something of the right general form
+// 3. If the list returned is empty, then the subtest is over. Otherwise, select the first element of the list and extract the "name" field
+// 4. Do a GET/describe on that particular session template
+// 5. Verify that this succeeds and returns something of the right general form
+
+func sessionTemplatesTestsAPI(params *common.Params, tenantList []string) (passed bool) {
+	passed = true
+
+	// session template template API tests
+	// Just do a GET of the sessiontemplatetemplate endpoint and make sure that the response has
+	// 200 status and a dictionary object
+
+	// v1
+	if !basicGetUriVerifyStringMapTest(bosV1SessionTemplateTemplateUri, params) {
+		passed = false
+	}
+
+	// v2
+	if !basicGetUriVerifyStringMapTest(bosV2SessionTemplateTemplateUri, params) {
+		passed = false
+	}
+
+	// session template API tests
+
+	// v1
+	if !v1SessionTemplatesTestsURI(params) {
+		passed = false
+	}
+
+	// v2
+	if !v2SessionTemplatesTestsURI(params, tenantList) {
+		passed = false
+	}
+
+	return
+}
+
+func sessionTemplatesTestsCLI() (passed bool) {
+	passed = true
+
+	// session template template CLI tests
+	// Make sure that "sessiontemplatetemplate list" CLI command succeeds and returns a dictionary object.
+
+	// v1 sessiontemplatetemplate list
+	if !basicCLIListVerifyStringMapTest("v1", bosV1SessionTemplateTemplateCLI) {
+		passed = false
+	}
+
+	// v2 sessiontemplatetemplate list
+	if !basicCLIListVerifyStringMapTest("v2", bosV2SessionTemplateTemplateCLI) {
+		passed = false
+	}
+
+	// sessiontemplatetemplate list
+	if !basicCLIListVerifyStringMapTest(bosDefaultSessionTemplateTemplateCLI) {
+		passed = false
+	}
+
+	// session template CLI tests
+
+	// v1 sessiontemplate
+	if !sessionTemplatesTestsCLICommand("v1", bosV1SessionTemplatesCLI) {
+		passed = false
+	}
+
+	// v2 sessiontemplates
+	if !sessionTemplatesTestsCLICommand("v2", bosV2SessionTemplatesCLI) {
+		passed = false
+	}
+
+	// sessiontemplates
+	if !sessionTemplatesTestsCLICommand(bosDefaultSessionTemplatesCLI) {
+		passed = false
+	}
+
+	return
+}
+
+// v1 session templates API test
+func v1SessionTemplatesTestsURI(params *common.Params) bool {
+	var untenantedTemplateData v2TemplateData
+	var err error
+	var templateDataList []v2TemplateData
+
+	// test #1, list templates
+	templateDataList, err = listV1TemplateDataApi(params)
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(templateDataList) == 0 {
+		common.Infof("skipping test GET %s/{session_template_id}", bosV1SessionTemplatesUri)
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// From the session template ID list, we want to identify:
+	// * One session template that has no tenant (untenantedTemplateData)
+	for sessionTemplateIndex, TemplateData := range templateDataList {
+		common.Debugf("Parsing session #%d in the session list (%s)", sessionTemplateIndex, TemplateData.String())
+		if len(TemplateData.Tenant) != 0 {
+			continue
+		}
+		// This is the first session template we have encountered that has no tenant field,
+		// so take note of it
+		untenantedTemplateData = TemplateData
+		common.Infof("Found BOS session template #%d (%s)", sessionTemplateIndex, untenantedTemplateData.String())
+		break
+	}
+
+	if untenantedTemplateData.IsNil() {
+		common.Infof("skipping test GET %s/{session_template_id} with no tenant specified, because all BOS session templates are owned by tenants",
+			bosV1SessionTemplatesUri)
+		return true
+	}
+	// test: describe session template using the untenanted session template name we found earlier
+	_, err = getV1TemplateDataApi(params, untenantedTemplateData.Name)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+	return true
+}
+
+// v2 session templates API tests
+// See comment earlier in the file for a general description of this function
+//
+// The v2 API version of this function has had further improvements made in order to test good-path multitenancy
+// queries. Specifically, this function now does the following (all using API calls)
+// 1. API query to list all BOS v2 session templates (no tenant name specified)
+// 2. Parses the result, verifying that it is a JSON list, and verifying that each item in that list:
+//    a. Is a JSON dictionary
+//    b. Has a "name" field which maps to a non-0-length string
+//    c. Either has no "tenant" field or has a "tenant" field that maps to a (possibly 0-length) string
+// 3. If the list is empty, then pick a random tenant name (possibly not one which exists on the system)
+//    and issue a query for all BOS session templates belonging to that tenant. Verify that the resulting list is empty.
+// 4. If the list from #1 is not empty, but no session templates belong to a tenant, then do #3.
+// 5. If the list from #1 is not empty and has session templates owned by a tenant, then pick one such tenant, pick above
+//    session template owned by that tenant, and also count how many total session templates are owned by that tenant.
+//    a. Query for all BOS session templates belonging to that tenant and verify that we get the same total number. Also
+//       perform the same validation steps as in #2, and validate that every returned session template belongs to the specified tenant.
+//    b. Query for the specific BOS session template belonging to that tenant and verify that it can be retrieved.
+// 6. If the list from #1 is not empty and has at least one session template that is not owned by a tenant, then pick such
+//    a session template, query BOS for that specific session template, and verify that it can be retrieved.
+
+// Several of these checks could fail if BOS session templates are being created or deleted while this test is running.
+// For now, this will be a documented limitation of the test, with the recommendation to re-run just
+// the BOS health check in the case that certain failures are seen. Eventually the test could be improved to automatically
+// retry the relevant checks a limited number of times, to reduce the likelihood of false failures.
+
+func v2SessionTemplatesTestsURI(params *common.Params, tenantList []string) bool {
+	var tenantedTemplateData, untenantedTemplateData v2TemplateData
+	var tenantedTemplateCount int
+	var err error
+	var templateDataList []v2TemplateData
+
+	// test #1, list templates
+	templateDataList, err = listV2TemplateDataApi(params, "")
+	if err != nil {
+		common.Error(err)
+		return false
+	} else if len(templateDataList) == 0 {
+		common.Infof("skipping test GET %s/{session_template_id}", bosV2SessionTemplatesUri)
+		common.Infof("results from previous test is []")
+
+		// However, we can still try to list all of the session templates with a tenant name specified.
+		// Since no session templates were found from the un-tenanted query, we expect none to be found once a tenant
+		// is specified
+		tenant := getAnyTenant(tenantList)
+		templateDataList, err = listV2TemplateDataApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			return false
+		}
+
+		// Validate that this list is empty
+		if len(templateDataList) > 0 {
+			common.Errorf("Listing of all session templates empty, but found %d when listing session templates for tenant '%s'",
+				len(templateDataList), tenant)
+			return false
+		}
+		common.Infof("Session template list is still empty, as expected")
+		return true
+	}
+
+	// From the session template ID list, we want to identify:
+	// * One session template that has no tenant (untenantedTemplateData)
+	// * One session template that belongs to a tenant (tenantedTemplateData), and a count (tenantedTemplateCount)
+	//   of how many session templates in total have that same tenant
+	for sessionTemplateIndex, TemplateData := range templateDataList {
+		common.Debugf("Parsing session #%d in the session list (%s)", sessionTemplateIndex, TemplateData.String())
+		if len(TemplateData.Tenant) == 0 {
+			// This session template has no tenant
+			if untenantedTemplateData.IsNil() {
+				// This is the first session template we have encountered that has no tenant field,
+				// so take note of it
+				untenantedTemplateData = TemplateData
+				common.Infof("Found BOS v2 session template #%d (%s)", sessionTemplateIndex, untenantedTemplateData.String())
+			}
+			continue
+		}
+		// This session template is owned by a tenant.
+		if tenantedTemplateData.IsNil() {
+			// This is the first session template we've found that is owned by a tenant, so remember it,
+			// and note that we have found 1 session template belonging to this tenant so far
+			tenantedTemplateData = TemplateData
+			tenantedTemplateCount = 1
+			common.Infof("Found BOS v2 session template #%d (%s)", sessionTemplateIndex, tenantedTemplateData.String())
+			continue
+		}
+		// We have already found a session template belonging to a tenant. If it is the tenant we found first,
+		// increment our session count
+		if TemplateData.Tenant == tenantedTemplateData.Tenant {
+			tenantedTemplateCount += 1
+		}
+	}
+
+	passed := true
+
+	if untenantedTemplateData.IsNil() {
+		common.Infof("skipping test GET %s/{session_template_id} with no tenant specified, because all BOS v2 session templates are owned by tenants",
+			bosV2SessionTemplatesUri)
+	} else {
+		// test: describe session template using the untenanted session template name we found earlier
+		_, err = getV2TemplateDataApi(params, untenantedTemplateData)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		}
+	}
+
+	if tenantedTemplateData.IsNil() {
+		common.Infof("No BOS v2 session templates found belonging to any tenants")
+
+		tenant := getAnyTenant(tenantList)
+		templateDataList, err = listV2TemplateDataApi(params, tenant)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		} else {
+			// Validate that this list is empty
+			if len(templateDataList) > 0 {
+				common.Errorf("Listing all session templates found none owned by tenants, but found %d when listing session templates for tenant '%s'",
+					len(templateDataList), tenant)
+				passed = false
+			}
+			common.Infof("List of session templates belonging to tenant '%s' is empty, as expected", tenant)
+		}
+		return passed
+	}
+	common.Infof("Counted %d BOS v2 session templates belonging to tenant '%s'", tenantedTemplateCount, tenantedTemplateData.Tenant)
+	templateDataList, err = listV2TemplateDataApi(params, tenantedTemplateData.Tenant)
+	if err != nil {
+		common.Error(err)
+		passed = false
+	} else {
+		// Validate that this list is expected length
+		if len(templateDataList) != tenantedTemplateCount {
+			common.Errorf("Listing all session templates found %d owned by tenant '%s', but found %d when listing session templates for that tenant",
+				tenantedTemplateCount, tenantedTemplateData.Tenant, len(templateDataList))
+			passed = false
+		}
+		common.Infof("List of session templates belonging to tenant '%s' is the expected length", tenantedTemplateData.Tenant)
+	}
+
+	// test: describe session template using the session template name we found owned by a tenant in the earlier loop
+	_, err = getV2TemplateDataApi(params, tenantedTemplateData)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	return passed
+}
+
+// session templates CLI tests
+// See comment earlier in the file for a description of this function
+func sessionTemplatesTestsCLICommand(cmdArgs ...string) bool {
+	var untenantedTemplateData v2TemplateData
+
+	// test #1, list session templates
+	templateDataList, passed := listTemplateDataCli(cmdArgs...)
+	if !passed {
+		return false
+	}
+	if len(templateDataList) == 0 {
+		common.Infof("skipping test CLI %s describe {template_id}", strings.Join(cmdArgs, " "))
+		common.Infof("results from previous test is []")
+		return true
+	}
+
+	// From the template ID list, we want to identify:
+	// * One template that has no tenant (untenantedTemplateData)
+	for templateIndex, templateData := range templateDataList {
+		common.Debugf("Parsing template #%d in the template list (%s)", templateIndex, templateData.String())
+		if len(templateData.Tenant) == 0 {
+			// This template has no tenant
+			untenantedTemplateData = templateData
+			common.Infof("Found BOS template #%d (%s)", templateIndex, untenantedTemplateData.String())
+			break
+		}
+	}
+
+	if untenantedTemplateData.IsNil() {
+		common.Infof("skipping test CLI %s describe {template_id} with no tenant specified, because all BOS templates are owned by tenants",
+			strings.Join(cmdArgs, " "))
+		return true
+	}
+
+	// an untenanted session template id is available
+	// test #2 describe session templates
+	cmdOut := runBosCLIDescribe(untenantedTemplateData.Name, cmdArgs...)
+	if cmdOut == nil {
+		return false
+	}
+	return ValidateTemplateData(cmdOut, untenantedTemplateData)
+}

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -43,7 +43,7 @@ const bosV1VersionCLI = "version"
 const bosV2VersionCLI = "version"
 const bosDefaultVersionCLI = bosV2VersionCLI
 
-func versionTestsAPI(params *common.Params) (passed bool) {
+func versionTestsAPI(params *common.Params, tenantList []string) (passed bool) {
 	passed = true
 
 	// / endpoint
@@ -72,7 +72,7 @@ func versionTestsAPI(params *common.Params) (passed bool) {
 	}
 
 	// v2 endpoint as random tenant (BOS does not verify that tenant exists on GET requests)
-	if !basicTenantGetUriVerifyStringMapTest(bosV2BaseUri, "cmsdev-tenant", params) {
+	if !basicTenantGetUriVerifyStringMapTest(bosV2BaseUri, getAnyTenant(tenantList), params) {
 		passed = false
 	}
 
@@ -82,7 +82,7 @@ func versionTestsAPI(params *common.Params) (passed bool) {
 	}
 
 	// /v2/version endpoint as random tenant (BOS does not verify that tenant exists on GET requests)
-	if !basicTenantGetUriVerifyStringMapTest(bosV2VersionUri, "cmsdev-tenant", params) {
+	if !basicTenantGetUriVerifyStringMapTest(bosV2VersionUri, getAnyTenant(tenantList), params) {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_version.go
+++ b/cmsdev/internal/test/bos/bos_version.go
@@ -71,8 +71,18 @@ func versionTestsAPI(params *common.Params) (passed bool) {
 		passed = false
 	}
 
+	// v2 endpoint as random tenant (BOS does not verify that tenant exists on GET requests)
+	if !basicTenantGetUriVerifyStringMapTest(bosV2BaseUri, "cmsdev-tenant", params) {
+		passed = false
+	}
+
 	// /v2/version endpoint
 	if !basicGetUriVerifyStringMapTest(bosV2VersionUri, params) {
+		passed = false
+	}
+
+	// /v2/version endpoint as random tenant (BOS does not verify that tenant exists on GET requests)
+	if !basicTenantGetUriVerifyStringMapTest(bosV2VersionUri, "cmsdev-tenant", params) {
 		passed = false
 	}
 


### PR DESCRIPTION
## Summary and Scope

This adds good path multitenancy GET API tests for supported BOS v2 endpoints. For version and health endpoints, it just tries the same queries with a tenant specified.

For sessions, and session templates, first it lists all items, with no tenant specified. If any items are listed that belong to a tenant, then it also tests listing all items that belong to that tenant, as well as doing a GET for a specific item owned by that tenant (found from the original listing). 

If no items owned by tenants are found, it still attempts to list all items belonging to a random (possibly nonexistent) tenant, and just verifies that the response is an empty list, as expected.

For components, it also starts by making an untenanted query to list all components, and does a GET request on the first item in the list (if any). If the system has a tenants defined, then the test will also make a query for all components belonging to a random tenant. If any are returned, the test will do a tenanted GET request for a component owned by that tenant.

## Issues and Related PRs

* Resolves [CASMCMS-8553](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8553)

## Testing

Between mug and vshasta, I have tested all of the new and changed code paths.

## Risks and Mitigations

Moderate risk. The new test logic is very similar to the existing test logic, but a fair amount of new code was written to implement it. Given the testing that I have done, and given the time between now and the CSM 1.5 release, I do not think this is a high risk change.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
