### PR TITLE
CASMCMS-8872: cmsdev: Add --no-cleanup option to make debug easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2023-11-30
+
+### Added
+
+- cmsdev: Added `--no-cleanup` option to prevent deleting of temporary test files, to help in debug.
+
 ### Dependencies
+
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#149](https://github.com/Cray-HPE/cms-tools/pull/149))
 - Bump `google.golang.org/appengine` from 1.6.7 to 1.6.8 ([#151](https://github.com/Cray-HPE/cms-tools/pull/151))
 - Bump `github.com/mattn/go-isatty` from 0.0.19 to 0.0.20 ([#152](https://github.com/Cray-HPE/cms-tools/pull/152))
@@ -15,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.15.0] - 2023-09-28
 
 ### Changed
+
 - cray-upload-recovery-images: Added chmod to make sure files are world readable after upload.
 
 ### Dependencies
@@ -237,7 +245,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.15.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.16.0...HEAD
+
+[1.16.0]: https://github.com/Cray-HPE/cms-tools/compare/1.15.0...1.16.0
 
 [1.15.0]: https://github.com/Cray-HPE/cms-tools/compare/1.14.1...1.15.0
 


### PR DESCRIPTION
## Summary and Scope

While debugging [CASMTRIAGE-6371](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6371), it became apparent that it would be very nice if the cmsdev test tool had an option that stopped it from deleting the temporary test files it creates during execution.

This PR adds that option. It is a very small change -- adding the new command line option, and then using it to determine whether or not to set a deferred call to the function that deletes the temporary directory.

## Issues and Related PRs

* Inspired by debug of [CASMTRIAGE-6371](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6371)
* Resolves [CASMCMS-8872](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8872)

## Testing

I tested this on starlord (running CSM 1.5.0-beta.79), running tests both with and without the new option specified. In both cases, it behaved as expected (and made debugging the triage problem on there MUCH easier).

## Risks and Mitigations

Very low risk -- change is very small.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
