### PR TITLE
CASMTRIAGE-6578: Updated cray-tftp-upload script to handle more than one ipxe pod (CSM1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2024-02-08
+
+### Changed
+- Update to cray-tftp-upload to work with more than one ipxe pod and fixed return error.
+
 ## [1.16.0] - 2023-11-30
 
 ### Added
@@ -245,7 +250,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.16.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.16.1...HEAD
+
+[1.16.1]: https://github.com/Cray-HPE/cms-tools/compare/1.16.0...1.16.1
 
 [1.16.0]: https://github.com/Cray-HPE/cms-tools/compare/1.15.0...1.16.0
 

--- a/cms-tftp/cray-tftp-upload
+++ b/cms-tftp/cray-tftp-upload
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2021, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,6 +24,10 @@
 
 UPLOAD_FILE=$1
 PVC_HOST=`kubectl get pods -n services -l app.kubernetes.io/instance=cms-ipxe -o custom-columns=NS:.metadata.name --no-headers`
+# if more then one host is returned, use the 1st one.
+if [ `echo $PVC_HOST | wc -w` -gt 1 ]; then
+  PVC_HOST=`echo $PVC_HOST | awk '{print $1}'`
+fi
 PVC_PATH="/shared_tftp"
 
 usage()
@@ -45,9 +49,10 @@ else
     echo "$UPLOAD_FILE is not a file. Exiting."
     exit 1
 fi
-if [ $? -ne 0 ]; then
-    echo "Failed to upload $UPLOAD_FILE - error code = $?"
-    exit $?
+retval=$?
+if [ $retval -ne 0 ]; then
+    echo "Failed to upload $UPLOAD_FILE - error code = $retval"
+    exit $retval
 else
     echo "Successfully uploaded $UPLOAD_FILE!"
 fi


### PR DESCRIPTION
(cherry picked from commit 85567454e110924d4988c7dc2a17470e3a4c04ec)
(cherry picked from commit bf705bf451d136ca050700c17c00c1e35da685be)
(cherry picked from commit 50d5e08ecaf4a1cf298e5f78a1a01eede83c3f88)
(cherry picked from commit 4a7e646bde314afe0f6796ffcaff3c24505e701b)
