### PR TITLE
CASMCMS-7329: cmsdev: Remove BOS-v1-specific checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2024-03-15
+
+### Changed
+- Remove BOS-v1-specific checks from `cmsdev` BOS test.
+
 ## [1.19.1] - 2024-02-23
 
 ### Changed
@@ -298,7 +303,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.19.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cms-tools/compare/1.20.0...HEAD
+
+[1.20.0]: https://github.com/Cray-HPE/cms-tools/compare/1.19.1...1.20.0
 
 [1.19.1]: https://github.com/Cray-HPE/cms-tools/compare/1.19.0...1.19.1
 

--- a/cmsdev/internal/test/bos/bos.go
+++ b/cmsdev/internal/test/bos/bos.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,19 +29,10 @@ package bos
  */
 
 import (
-	"regexp"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
-	"strings"
 )
-
-var optionalCompletedPodNames = []string{
-	"cray-bos-wait-for-etcd-",
-	"cray-bos-bitnami-etcd-snapshotter-",
-	"cray-bos-etcd-post-install-",
-	"cray-bos-pre-upgrade-etcd-backup-",
-}
 
 // For tests which need a tenant name, if they can work even with a nonexistent tenant, use the
 // following name if no actual tenants exist
@@ -74,20 +65,10 @@ func IsBOSRunning() (passed bool) {
 	common.Infof("Found %d bos pods", len(podNames))
 	// The BOS pod zoo has become rather unruly. Parts of this test were
 	// passing more by accident than anything else. Given that, this
-	// section of the check has been simplified to just make sure that there
-	// are 3 etcd pods, and that any transient pods, if they exist, have succeeded.
+	// section of the check has been simplified.
 
 	// Check for:
-	// Exactly 3 BOS etcd pods
-	// All pods are expected to be Running except for the following, which are expected to
-	// be Succeeded if they exist:
-	// - cray-bos-wait-for-etcd
-	// - cray-bos-bitnami-etcd-snapshotter
-	// - cray-bos-etcd-post-install
-	// - cray-bos-pre-upgrade-etcd-backup
-	etcPodCount := 0
-	etcdRe := regexp.MustCompile("cray-bos-bitnami-etcd-[0-9]")
-	pvcNames := make([]string, 0, 3)
+	// All pods are expected to be Running
 	for _, podName := range podNames {
 		common.Infof("Getting pod status for %s", podName)
 		status, err := k8s.GetPodStatus(common.NAMESPACE, podName)
@@ -99,43 +80,16 @@ func IsBOSRunning() (passed bool) {
 			common.Infof("Pod %s status is %s", podName, status)
 		}
 
-		expectedStatus := "Running"
-		if etcdRe.MatchString(podName) {
-			etcPodCount += 1
-			// There should be a corresponding pvc with the same name prepended with "data-"
-			pvcName := "data-" + podName
-			common.Infof("There should be a corresponding pvc for this pod (%s) with the name '%s'", podName, pvcName)
-			pvcNames = append(pvcNames, pvcName)
-			if !test.CheckPVCStatus(pvcName) {
-				passed = false
-			}
-		} else {
-			for _, podPrefix := range optionalCompletedPodNames {
-				if strings.HasPrefix(podName, podPrefix) {
-					// These pods, if they exist, are expected to be Succeeded
-					expectedStatus = "Succeeded"
-					break
-				}
-			}
-		}
-
-		if status != "" && status != expectedStatus {
-			common.VerboseFailedf("Pod %s has status %s, but we expect it to be %s", podName, status, expectedStatus)
+		if status != "" && status != "Running" {
+			common.VerboseFailedf("Pod %s has status %s, but we expect it to be Running", podName, status)
 			passed = false
 		}
-	}
-	if etcPodCount != 3 {
-		common.VerboseFailedf("Found %d cray-bos-etcd- pod(s), but expect to find 3", etcPodCount)
-		passed = false
 	}
 
 	if !passed {
 		common.ArtifactsKubernetes()
 		if len(podNames) > 0 {
 			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
-		}
-		if len(pvcNames) > 0 {
-			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
 		}
 	}
 


### PR DESCRIPTION
Remove the remaining test checks that are specific to BOS v1 and that will fail once it is removed.