### PR TITLE
CASMCMS-8958: cmsdev: Add CFS v3 coverage; make v2 testing aware of v3 pagination changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmsdev/bin/cmsdev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added/Changed
+- `cmsdev`: Overhauled CFS API and CLI checks, primarily to prevent them from failing with the addition of pagination
+  in CFS v3. However, prior to this, the test only covered CFS v2. This modifies it to include CFS v3. In addition, it
+  adds coverage to some overlooked endpoints.
+
+### Removed
+- `cmsdev` CFS test no longer checks status of components in CFS. Customers use SAT for this already, and this really only
+  served to make people think there were CFS errors just because a CFS configuration session failed on a node.
+
 ## [1.20.0] - 2024-03-15
 
 ### Changed

--- a/cmsdev/internal/test/cfs/cfs.go
+++ b/cmsdev/internal/test/cfs/cfs.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,29 +29,12 @@ package cfs
  */
 
 import (
-	"net/http"
 	"regexp"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
 	"strings"
 )
-
-// CMS service endpoints
-var endpoints map[string]map[string]*common.Endpoint = common.GetEndpoints()
-
-var cfsEndpoints = []string{
-	"components",
-	"configurations",
-	"options",
-	"sessions",
-}
-
-var cfsEndpointIdFieldName = map[string]string{
-	"components":     "id",
-	"configurations": "name",
-	"sessions":       "name",
-}
 
 func IsCFSRunning() (passed bool) {
 	passed = true
@@ -110,266 +93,10 @@ func IsCFSRunning() (passed bool) {
 	if !testCFSCLI() {
 		passed = false
 	}
-	if !checkCfsComponentsStatus() {
-		passed = false
-	}
 	if !passed {
 		common.ArtifactsKubernetes()
 		if len(podNames) > 0 {
 			common.ArtifactDescribeNamespacePods(common.NAMESPACE, podNames)
-		}
-	}
-	return
-}
-
-func runCLICommand(cmdArgs ...string) []byte {
-	return test.RunCLICommandJSON("cfs", cmdArgs...)
-}
-
-func checkIDField(mapCmdOut []byte, cfsEndpoint, idFieldName, expectedIdValue string) bool {
-	// The endpoint names are plural ending in s -- this makes it singular
-	objectName := "CFS " + cfsEndpoint[:len(cfsEndpoint)-1]
-	err := common.ValidateStringFieldValue(objectName, idFieldName, expectedIdValue, mapCmdOut)
-	if err != nil {
-		common.Error(err)
-		return false
-	}
-	return true
-}
-
-// Make basic CFS API calls, checking only status code at this point
-func testCFSCLI() (passed bool) {
-	passed = true
-
-	common.Infof("Checking CFS CLI endpoints")
-	for _, cfsEndpoint := range cfsEndpoints {
-		common.Infof("CLI: Listing CFS %s", cfsEndpoint)
-		cmdOut := runCLICommand(cfsEndpoint, "list")
-		if cmdOut == nil {
-			passed = false
-			continue
-		}
-
-		idFieldName, ok := cfsEndpointIdFieldName[cfsEndpoint]
-		if !ok {
-			// This endpoint has no GET/describe command
-			continue
-		}
-
-		// If our list has any entries, let's get the ID field of the
-		// first entry. Then we can do a GET/describe on that object
-		idValue, err := common.GetStringFieldFromFirstItem(idFieldName, cmdOut)
-		if err != nil {
-			common.Error(err)
-			passed = false
-			continue
-		} else if len(idValue) == 0 {
-			common.Infof("No CFS %s listed -- skipping CLI describe test", cfsEndpoint)
-			continue
-		}
-
-		common.Infof("CLI: Describing CFS %s %s", cfsEndpoint, idValue)
-		cmdOut = runCLICommand(cfsEndpoint, "describe", idValue)
-		if cmdOut == nil {
-			passed = false
-			continue
-		}
-
-		// Validate that we find the expected ID field value
-		if !checkIDField(cmdOut, cfsEndpoint, idFieldName, idValue) {
-			passed = false
-		}
-	}
-	return
-}
-
-// Make basic CFS API calls, checking only status code at this point
-func testCFSAPI() (passed bool) {
-	var url string
-	var baseurl string = common.BASEURL
-
-	passed = false
-	common.Infof("Checking CFS API endpoints")
-	params := test.GetAccessTokenParams()
-	if params == nil {
-		return
-	}
-	passed = true
-
-	common.Infof("API: Checking CFS service health")
-	url = baseurl + endpoints["cfs"]["healthz"].Url
-	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
-	if err != nil {
-		common.Error(err)
-		passed = false
-	} else {
-		// At least verify that the response object is a string map as we expect
-		_, err = common.DecodeJSONIntoStringMap(resp.Body())
-		if err != nil {
-			common.Error(err)
-			passed = false
-		}
-	}
-
-	for _, cfsEndpoint := range cfsEndpoints {
-		common.Infof("API: Listing CFS %s", cfsEndpoint)
-		url = baseurl + endpoints["cfs"][cfsEndpoint].Url
-		resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
-		if err != nil {
-			common.Error(err)
-			passed = false
-			continue
-		}
-
-		idFieldName, ok := cfsEndpointIdFieldName[cfsEndpoint]
-		if !ok {
-			// This endpoint has no GET/describe command
-			continue
-		}
-
-		// If our list has any entries, let's get the ID field of the
-		// first entry. Then we can do a GET/describe on that object
-		idValue, err := common.GetStringFieldFromFirstItem(idFieldName, resp.Body())
-		if err != nil {
-			common.Error(err)
-			passed = false
-			continue
-		} else if len(idValue) == 0 {
-			common.Infof("No CFS %s listed -- skipping API GET specific %s test", cfsEndpoint, cfsEndpoint)
-			continue
-		}
-
-		common.Infof("API: Getting CFS %s %s", cfsEndpoint, idValue)
-		url += "/" + idValue
-		resp, err = test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
-		if err != nil {
-			common.Error(err)
-			passed = false
-			continue
-		}
-
-		// Validate that we find the expected ID field value
-		if !checkIDField(resp.Body(), cfsEndpoint, idFieldName, idValue) {
-			passed = false
-		}
-	}
-	return
-}
-
-func checkCfsComponentsStatus() (passed bool) {
-	// We keep a map of the status of each id we have seen, so that we do not report
-	// errors twice for the same id when we check it using both the CLI and API
-	var cfsComponentIdConfigStatus = map[string]string{}
-	var url string
-	var baseurl string = common.BASEURL
-	passed = true
-
-	// First list the CFS components using the API
-	params := test.GetAccessTokenParams()
-	if params == nil {
-		passed = false
-	} else {
-		common.Infof("API: Listing CFS components")
-		url = baseurl + endpoints["cfs"]["components"].Url
-		resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
-		if err != nil {
-			common.Error(err)
-			passed = false
-		} else {
-			common.Infof("Validating configurationStatuses of components listed by API call (if any)")
-			if !checkCfsComponentsStatusHelper(resp.Body(), cfsComponentIdConfigStatus) {
-				passed = false
-			}
-		}
-	}
-
-	// Now do the same via the CLI
-	common.Infof("CLI: Listing CFS components")
-	cmdOut := runCLICommand("components", "list")
-	if cmdOut == nil {
-		passed = false
-	} else {
-		common.Infof("Validating configurationStatuses of components listed by CLI call (if any)")
-		if !checkCfsComponentsStatusHelper(cmdOut, cfsComponentIdConfigStatus) {
-			passed = false
-		}
-	}
-
-	if passed {
-		common.Infof("No errors when checking configurationStatuses of CFS components")
-	} else {
-		common.Infof("At least one error found when checking configurationStatuses of CFS components")
-	}
-	return
-}
-
-// For each component in the list, examine its status field.
-// We expect status "configured"
-// For status "unconfigured" or "pending" we record a warning
-// For status "failed" we report an error
-// An error is also reported for any status other than the four listed above, as they
-// are the only ones that should ever be found.
-func checkCfsComponentsStatusHelper(compListJSONBytes []byte, compIdStatus map[string]string) (passed bool) {
-	passed = true
-
-	// First, convert the output into a list
-	listObject, err := common.DecodeJSONIntoList(compListJSONBytes)
-	if err != nil {
-		common.Error(err)
-		passed = false
-		return
-	}
-
-	idFieldName := cfsEndpointIdFieldName["components"]
-
-	for _, componentObject := range listObject {
-		component, ok := componentObject.(map[string]interface{})
-		if !ok {
-			common.Errorf("One of the items in the component list is not a dictionary: %v", componentObject)
-			passed = false
-			continue
-		}
-
-		common.Debugf("Checking CFS component: %v", component)
-
-		componentId, err := common.GetStringFieldFromMapObject(idFieldName, component)
-		if err != nil {
-			passed = false
-			common.Error(err)
-		}
-
-		componentConfigStatus, err := common.GetStringFieldFromMapObject("configurationStatus", component)
-		if err != nil {
-			passed = false
-			common.Error(err)
-		}
-
-		previousStatus, ok := compIdStatus[componentId]
-		if ok {
-			if previousStatus == componentConfigStatus {
-				common.Infof("CFS component id %s still has configurationStatus '%s'", componentId, componentConfigStatus)
-				continue
-			} else {
-				common.Infof("CFS component id %s configurationStatus has changed from our last check", componentId)
-			}
-		}
-		compIdStatus[componentId] = componentConfigStatus
-
-		message := "CFS component id %s has configurationStatus '%s'"
-		if componentConfigStatus == "configured" {
-			common.Infof(message, componentId, componentConfigStatus)
-		} else if componentConfigStatus == "failed" {
-			common.Errorf(message, componentId, componentConfigStatus)
-			passed = false
-		} else if componentConfigStatus == "unconfigured" {
-			common.Warnf(message, componentId, componentConfigStatus)
-			common.Infof("It is unusual for a CFS component to have this configurationStatus except after CSM product install")
-		} else if componentConfigStatus == "pending" {
-			common.Warnf(message, componentId, componentConfigStatus)
-			common.Infof("Monitor this CFS component, or re-run this test, to confirm that this component gets configured successfully")
-		} else {
-			common.Errorf("CFS component id %s has unexpected configurationStatus '%s'", componentId, componentConfigStatus)
-			passed = false
 		}
 	}
 	return

--- a/cmsdev/internal/test/cfs/cfs_api.go
+++ b/cmsdev/internal/test/cfs/cfs_api.go
@@ -1,0 +1,430 @@
+// MIT License
+//
+// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+package cfs
+
+/*
+ * cfs_api.go
+ *
+ * CFS API definitions
+ *
+ */
+
+import (
+	"fmt"
+	"net/http"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
+
+const cfsBaseUrl = common.BASEURL + "/apis/cfs"
+const cfsHealthzUrl = cfsBaseUrl + "/healthz"
+const cfsMaxVersion = 3
+const cfsMinVersion = 2
+
+var cfsVersionUrls = []string{cfsBaseUrl + "/", cfsBaseUrl + "/versions", cfsBaseUrl + "/v2", cfsBaseUrl + "/v3"}
+
+type cfsEndpoint struct {
+	Name     string // This must equal what you need to specify in the URI string
+	IdField  string
+	Versions []int
+}
+
+var cfsEndpoints = []cfsEndpoint{
+	{
+		Name:     "components",
+		IdField:  "id",
+		Versions: []int{2, 3},
+	},
+	{
+		Name:     "configurations",
+		IdField:  "name",
+		Versions: []int{2, 3},
+	},
+	{
+		Name:     "sessions",
+		IdField:  "name",
+		Versions: []int{2, 3},
+	},
+	{
+		Name:     "sources",
+		IdField:  "name",
+		Versions: []int{3},
+	},
+}
+
+func (endpoint cfsEndpoint) InVersion(version int) bool {
+	for _, ver := range endpoint.Versions {
+		if ver == version {
+			return true
+		}
+	}
+	return false
+}
+
+func (endpoint cfsEndpoint) Url(version int) string {
+	return fmt.Sprintf("%s/v%d/%s", cfsBaseUrl, version, endpoint.Name)
+}
+
+func (endpoint cfsEndpoint) RunCliCommand(version int, cmdArgs ...string) []byte {
+	cmdPrefix := []string{fmt.Sprintf("v%d", version), endpoint.Name}
+	return test.RunCLICommandJSON("cfs", append(cmdPrefix, cmdArgs...)...)
+}
+
+func (endpoint cfsEndpoint) TestApi(params *common.Params) (passed bool) {
+	passed = true
+	var itemsList []interface{}
+	common.Infof("API: Testing CFS %s endpoint", endpoint.Name)
+	version := cfsMaxVersion + 1
+	multiplePages := false
+	for version > cfsMinVersion {
+		version -= 1
+		if endpoint.skipTest(version, multiplePages) {
+			continue
+		}
+		common.Infof("API: Listing CFS %s using v%d endpoint", endpoint.Name, version)
+		url := endpoint.Url(version)
+		resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+		if err != nil {
+			common.Error(err)
+			passed = false
+			continue
+		}
+
+		common.Debugf("API: Parsing response from CFS")
+		// Paging was implemented in CFS v3
+		if version < 3 {
+			itemsList, err = endpoint.parseUnpagedListResponse(resp.Body())
+			if err != nil {
+				common.Error(err)
+				passed = false
+				continue
+			}
+		} else {
+			itemsList, multiplePages, err = endpoint.parsePagedListResponse(resp.Body())
+			if err != nil {
+				common.Error(err)
+				passed = false
+				continue
+			}
+		}
+
+		if len(itemsList) == 0 {
+			common.Infof("API: GET %s returned an empty list -- skipping API test to get individual item", url)
+			continue
+		}
+
+		// The list has entries, so let's get the ID field of the
+		// first entry. Then we can do a GET/describe on that object
+		idFieldValue, err := endpoint.getFirstId(itemsList)
+		if err != nil {
+			common.Error(err)
+			passed = false
+			continue
+		}
+
+		// Now try to get this item directly
+		common.Infof("API: Getting CFS %s %s using v%d endpoint", endpoint.Name, idFieldValue, version)
+		url += "/" + idFieldValue
+		resp, err = test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+		if err != nil {
+			common.Error(err)
+			passed = false
+			continue
+		}
+
+		// Validate that we find the expected ID field value
+		err = endpoint.checkIDField(resp.Body(), idFieldValue)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		}
+	}
+	return
+}
+
+func (endpoint cfsEndpoint) TestCli() (passed bool) {
+	passed = true
+	var itemsList []interface{}
+	var err error
+	common.Infof("CLI: Testing CFS %s endpoint", endpoint.Name)
+	version := cfsMaxVersion + 1
+	multiplePages := false
+	for version > cfsMinVersion {
+		version -= 1
+		if endpoint.skipTest(version, multiplePages) {
+			continue
+		}
+		common.Infof("CLI: Listing CFS %s using v%d endpoint", endpoint.Name, version)
+		cmdOut := endpoint.RunCliCommand(version, "list")
+		if cmdOut == nil {
+			passed = false
+			continue
+		}
+
+		common.Debugf("API: Parsing response from CFS")
+		// Paging was implemented in CFS v3
+		if version < 3 {
+			itemsList, err = endpoint.parseUnpagedListResponse(cmdOut)
+			if err != nil {
+				common.Error(err)
+				passed = false
+				continue
+			}
+		} else {
+			itemsList, multiplePages, err = endpoint.parsePagedListResponse(cmdOut)
+			if err != nil {
+				common.Error(err)
+				passed = false
+				continue
+			}
+		}
+
+		if len(itemsList) == 0 {
+			common.Infof("CLI: v%d %s list returned an empty list -- skipping CLI test to get individual item", version, endpoint.Name)
+			continue
+		}
+
+		// The list has entries, so let's get the ID field of the
+		// first entry. Then we can do a GET/describe on that object
+		idFieldValue, err := endpoint.getFirstId(itemsList)
+		if err != nil {
+			common.Error(err)
+			passed = false
+			continue
+		}
+
+		// Now try to get this item directly
+		common.Infof("CLI: v%d %s describe %s", version, endpoint.Name, idFieldValue)
+		cmdOut = endpoint.RunCliCommand(version, "describe", idFieldValue)
+		if cmdOut == nil {
+			passed = false
+			continue
+		}
+
+		// Validate that we find the expected ID field value
+		err = endpoint.checkIDField(cmdOut, idFieldValue)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		}
+	}
+	return
+}
+
+func (endpoint cfsEndpoint) skipTest(version int, multiplePages bool) bool {
+	// Return True if the test of this CFS endpoint/version combo should be skipped
+	if !endpoint.InVersion(version) {
+		common.Debugf("%s endpoint is not supported in CFS v%d; skipping", endpoint.Name, version)
+		return true
+	} else if (version == 2) && multiplePages {
+		common.Infof("Too many %s in CFS to test v2 endpoint with current default page size; skipping", endpoint.Name)
+		return true
+	}
+	return false
+}
+
+func (endpoint cfsEndpoint) parseUnpagedListResponse(responseBytes []byte) ([]interface{}, error) {
+	// Paging was implemented in CFS v3, so if this is an earlier version, the response is a simple list
+	return common.DecodeJSONIntoList(responseBytes)
+}
+
+func (endpoint cfsEndpoint) parsePagedListResponse(responseBytes []byte) (itemsList []interface{}, multiplePages bool, err error) {
+	var mapObject map[string]interface{}
+	// Our response should be a map object with two fields -- endpoint.Name and "next"
+	// endpoint.Name should map to a list
+	// next should either be nil or map to a string map
+	mapObject, err = common.DecodeJSONIntoStringMap(responseBytes)
+	if err != nil {
+		return
+	}
+
+	nextRawValue, ok := mapObject["next"]
+	if !ok {
+		err = fmt.Errorf("Response is missing expected 'next' field")
+		return
+	}
+
+	itemsListRawValue, ok := mapObject[endpoint.Name]
+	if !ok {
+		err = fmt.Errorf("Response is missing expected '%s' field", endpoint.Name)
+		return
+	}
+
+	itemsList, ok = itemsListRawValue.([]interface{})
+	if !ok {
+		err = fmt.Errorf("Response field '%s' should map to a list but does not", endpoint.Name)
+		return
+	}
+
+	if nextRawValue == nil {
+		common.Debugf("Response field 'next' is nil, so there is only one page of items")
+		multiplePages = false
+	} else if _, ok = nextRawValue.(map[string]interface{}); ok {
+		common.Debugf("Response field 'next' is not nil, so there is more than one page of items")
+		multiplePages = true
+	} else {
+		err = fmt.Errorf("Response field 'next' should map to None or a dictionary, but does not")
+	}
+
+	return
+}
+
+func (endpoint cfsEndpoint) getFirstId(itemsList []interface{}) (idFieldValue string, err error) {
+	// This function should only be called after it has been verified that the
+	// list is not empty. The list has entries, so let's get the ID field of the
+	// first entry. Then we can do a GET/describe on that object
+	firstListEntry, ok := itemsList[0].(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("First item in list is not a dictionary, but should be")
+		return
+	}
+
+	idFieldRawValue, ok := firstListEntry[endpoint.IdField]
+	if !ok {
+		err = fmt.Errorf("First item in list is missing required '%s' field", endpoint.IdField)
+		return
+	}
+
+	idFieldValue, ok = idFieldRawValue.(string)
+	if !ok {
+		err = fmt.Errorf("In first item listed, '%s' field does not map to a string, but it should", endpoint.IdField)
+	}
+	return
+}
+
+func (endpoint cfsEndpoint) checkIDField(mapCmdOut []byte, expectedIdValue string) error {
+	// The endpoint names are plural ending in s -- this makes it singular
+	objectName := "CFS " + endpoint.Name[:len(endpoint.Name)-1]
+	return common.ValidateStringFieldValue(objectName, endpoint.IdField, expectedIdValue, mapCmdOut)
+}
+
+func validJSONStringMap(jsonBytes []byte) bool {
+	_, err := common.DecodeJSONIntoStringMap(jsonBytes)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+	return true
+}
+
+func testCFSAPI() (passed bool) {
+	passed = false
+	common.Infof("Checking CFS API endpoints")
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		return
+	}
+	passed = true
+
+	common.Infof("API: Checking CFS service health")
+	resp, err := test.RestfulVerifyStatus("GET", cfsHealthzUrl, *params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		passed = false
+	} else if !validJSONStringMap(resp.Body()) {
+		passed = false
+	}
+
+	common.Infof("API: Checking CFS version endpoints")
+	for _, url := range cfsVersionUrls {
+		resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		} else if !validJSONStringMap(resp.Body()) {
+			passed = false
+		}
+	}
+
+	common.Infof("API: Checking CFS option endpoints")
+	version := cfsMinVersion
+	for version <= cfsMaxVersion {
+		url := fmt.Sprintf("%s/v%d/options", cfsBaseUrl, version)
+		resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+		if err != nil {
+			common.Error(err)
+			passed = false
+		} else if !validJSONStringMap(resp.Body()) {
+			passed = false
+		}
+		version += 1
+	}
+
+	for _, endpoint := range cfsEndpoints {
+		if !endpoint.TestApi(params) {
+			passed = false
+		}
+	}
+	return
+}
+
+func testCFSCLI() (passed bool) {
+	passed = true
+
+	// cray cfs healthz list
+	common.Infof("CLI: Checking CFS service health")
+	cmdOut := test.RunCLICommandJSON("cfs", "healthz", "list")
+	if cmdOut == nil || !validJSONStringMap(cmdOut) {
+		passed = false
+	}
+
+	common.Infof("CLI: Checking CFS version endpoints")
+	// cray cfs list
+	cmdOut = test.RunCLICommandJSON("cfs", "list")
+	if cmdOut == nil || !validJSONStringMap(cmdOut) {
+		passed = false
+	}
+
+	// cray cfs versions list
+	cmdOut = test.RunCLICommandJSON("cfs", "versions", "list")
+	if cmdOut == nil || !validJSONStringMap(cmdOut) {
+		passed = false
+	}
+
+	// cray cfs v# list
+	version := cfsMinVersion
+	for version <= cfsMaxVersion {
+		cmdOut = test.RunCLICommandJSON("cfs", fmt.Sprintf("v%d", version), "list")
+		if cmdOut == nil || !validJSONStringMap(cmdOut) {
+			passed = false
+		}
+		version += 1
+	}
+
+	// cray cfs v# options list
+	common.Infof("API: Checking CFS option endpoints")
+	version = cfsMinVersion
+	for version <= cfsMaxVersion {
+		cmdOut = test.RunCLICommandJSON("cfs", fmt.Sprintf("v%d", version), "options", "list")
+		if cmdOut == nil || !validJSONStringMap(cmdOut) {
+			passed = false
+		}
+		version += 1
+	}
+
+	for _, endpoint := range cfsEndpoints {
+		if !endpoint.TestCli() {
+			passed = false
+		}
+	}
+	return
+}


### PR DESCRIPTION
The cmsdev CFS test was failing in cases where calls to CFS v2 exceeded the default page size, because cmsdev had not been updated to be aware of the CFS v3 pagination changes.

This PR overhauls the CFS API and CLI tests so that they have that awareness. It also adds in testing of CFS v3. Finally, it removes the checking of CFS component status, because that pretty much only resulted in people thinking CFS was having problems when it was just a product layer in a CFS session that failed to configure some node.

I tested these changes on fanta and mug, varying the page size value to make sure that the test handled the different scenarios.