### PR TITLE
CASMCMS-9017: Do not fail BOS test if etcd snapshotter pods are running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `cmsdev`: Do not fail BOS test if etcd snapshotter pods are running.
+
 ## [1.16.2] - 2024-04-03
 
 ### Added/Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.3] - 2024-06-03
+
 ### Changed
 - `cmsdev`: Do not fail BOS test if etcd snapshotter pods are running.
 


### PR DESCRIPTION
The CSM 1.5 version of the BOS subtest has a small chance of failing erroneously, if it happens to run when the bos-etcd-snapshotter job is starting up or running. This is because the test expected such pods to be Succeeded, and does not consider the possibility that they may be in progress.

The job runs once per hour and typically completed in under a couple of minutes, so it's not super likely, but we have seen it happen.

The fix is easy -- change the test requirement from such pods being Succeeded to allowing them to be Pending, Running, or Succeeded (in other words, only reporting a problem if they are Failed or Unknown). 

This isn't needed for CSM 1.6 because with the retirement of BOS v1, BOS no longer has an etcd DB, and thus no snapshotter.

I have tested this on mug and verified that it works (making sure to run it when the snapshotter job is underway).