### PR TITLE
CASMCMS-9029: cmsdev: More securely deal with credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Compile `cmsdev` with verbose flag
+- Modify VCS test to specify git credentials using environment variables rather than URL
+- Look up Kubernetes secrets using golang module instead of `kubectl` command
+- Do not log VCS credentials
+- When installing cmsdev RPM, remove from the log any previously-logged credentials
+- Do not log credentials when getting API token
 
 ### Dependencies
 - Bump `golang.org/x/net` from 0.17.0 to 0.23.0 ([#183](https://github.com/Cray-HPE/cms-tools/pull/183))

--- a/cmsdev/internal/lib/k8s/k8s.go
+++ b/cmsdev/internal/lib/k8s/k8s.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -27,11 +27,12 @@ package k8s
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	resty "gopkg.in/resty.v1"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -149,7 +150,6 @@ func RunCommandInContainer(podName, namespace, containerName string, cmdStrings 
 }
 
 func GetVcsUsernamePassword() (vcsUsername, vcsPassword string, err error) {
-	// TODO: clean this up. remove exec.Command and replace with clientgo
 	if len(VcsUser) != 0 && len(VcsPass) != 0 {
 		common.Debugf("Using cached values of vcs user and password")
 		vcsUsername = VcsUser
@@ -157,109 +157,30 @@ func GetVcsUsernamePassword() (vcsUsername, vcsPassword string, err error) {
 		return
 	}
 
-	var cmdOut []byte
-	var cmd *exec.Cmd
-
-	path, err := GetKubectlPath()
+	secret, err := GetSecret("services", "vcs-user-credentials")
 	if err != nil {
 		return
 	}
 
-	cmd = exec.Command(path, "get", "secret", "-n", "services", "vcs-user-credentials", "--template={{.data.vcs_username}}")
-	common.Debugf("Running command: %s", cmd)
-	cmdOut, err = cmd.CombinedOutput()
-	if len(cmdOut) > 0 {
-		common.Debugf("Command output: %s", cmdOut)
-	} else if err == nil {
-		err = fmt.Errorf("No output from command: %s", cmd)
-	} else {
-		common.Errorf("No output from command: %s", cmd)
-	}
+	vcsUsername, err = GetDataFieldFromSecret(secret, "vcs_username")
 	if err != nil {
 		return
 	}
-	base64Str := strings.TrimSpace(string(cmdOut))
-	common.Debugf("vcs username (base 64) = \"%s\"", base64Str)
-	common.Debugf("Decoding vcs username from base 64")
-	decodedBytes, err := base64.StdEncoding.DecodeString(base64Str)
-	if err != nil {
-		return
-	} else if len(decodedBytes) == 0 {
-		err = fmt.Errorf("Decoded string is empty")
-		return
-	}
-	vcsUsername = strings.TrimSpace(string(decodedBytes))
-	common.Debugf("Decoded vcs username = \"%s\"", vcsUsername)
 
-	cmd = exec.Command(path, "get", "secret", "-n", "services", "vcs-user-credentials", "--template={{.data.vcs_password}}")
-	common.Debugf("Running command: %s", cmd)
-	cmdOut, err = cmd.CombinedOutput()
-	if len(cmdOut) > 0 {
-		common.Debugf("Command output: %s", cmdOut)
-	} else if err == nil {
-		err = fmt.Errorf("No output from command: %s", cmd)
-	} else {
-		common.Errorf("No output from command: %s", cmd)
-	}
+	vcsPassword, err = GetDataFieldFromSecret(secret, "vcs_password")
 	if err != nil {
 		return
 	}
-	base64Str = strings.TrimSpace(string(cmdOut))
-	common.Debugf("vcs password (base 64) = \"%s\"", base64Str)
-	common.Debugf("Decoding vcs password from base 64")
-	decodedBytes, err = base64.StdEncoding.DecodeString(base64Str)
-	if err != nil {
-		return
-	} else if len(decodedBytes) == 0 {
-		err = fmt.Errorf("Decoded string is empty")
-		return
-	}
-	vcsPassword = strings.TrimSpace(string(decodedBytes))
-	common.Debugf("Decoded vcs password = \"%s\"", vcsPassword)
 	VcsUser = vcsUsername
 	VcsPass = vcsPassword
 	return
 }
 
 func GetOauthClientSecret() (string, error) {
-	// TODO: clean this up. remove exec.Command and replace with clientgo
-	var cmdOut []byte
-	var err error
-	var cmd *exec.Cmd
-
-	path, err := GetKubectlPath()
-	if err != nil {
-		return "", err
-	}
-	cmd = exec.Command(path, "get", "secrets", "admin-client-auth", "-ojsonpath='{.data.client-secret}'")
-	common.Debugf("Running command: %s", cmd)
-	cmdOut, err = cmd.CombinedOutput()
-	if len(cmdOut) > 0 {
-		common.Debugf("Command output: %s", cmdOut)
-	} else if err == nil {
-		err = fmt.Errorf("No output from command: %s", cmd)
-	} else {
-		common.Errorf("No output from command: %s", cmd)
-	}
-	if err != nil {
-		return "", err
-	}
-	cmdStr := fmt.Sprintf("echo %s | base64 -d", strings.Trim(string(cmdOut), "'"))
-	common.Debugf("Running command: %s", cmdStr)
-	cmdOut, err = exec.Command("bash", "-c", cmdStr).Output()
-	if len(cmdOut) > 0 {
-		common.Debugf("Command output: %s", cmdOut)
-	} else if err == nil {
-		err = fmt.Errorf("No output from command: %s", cmd)
-	} else {
-		common.Errorf("No output from command: %s", cmd)
-	}
-	return string(cmdOut), nil
+	return GetSecretDataField("default", "admin-client-auth", "client-secret")
 }
 
 func GetAccessJSON(params ...string) ([]byte, error) {
-	// TODO: clean this up. remove curl and replace with clientgo or a rest call
-	var cmdOut []byte
 	var err error
 	var clientSecret string = ""
 
@@ -278,19 +199,20 @@ func GetAccessJSON(params ...string) ([]byte, error) {
 		}
 		clientSecret = string(clientSecretByte)
 	}
-
-	cmdStr := fmt.Sprintf("curl -k -s -d grant_type=client_credentials -d client_id=admin-client -d client_secret=%s "+
-		"https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token", clientSecret)
-	common.Debugf("Running command: bash -c \"%s\"", cmdStr)
-	cmdOut, err = exec.Command("bash", "-c", cmdStr).Output()
+	client := resty.New()
+	client.SetHeader("Content-Type", "application/json")
+	client.SetFormData(map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     "admin-client",
+		"client_secret": clientSecret,
+	})
+	resp, err := client.R().Post("https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token")
 	if err != nil {
-		if len(cmdOut) > 0 {
-			common.Debugf("Command output: %s", cmdOut)
-		}
 		return nil, err
-	} else {
-		return cmdOut, nil
+	} else if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("POST to Keycloak: expected status code %d, got %d", http.StatusOK, resp.StatusCode())
 	}
+	return resp.Body(), nil
 }
 
 func GetAccessToken(params ...string) (string, error) {
@@ -384,6 +306,41 @@ func GetNodeNames(params ...string) ([]string, error) {
 		names = append(names, node.ObjectMeta.Name)
 	}
 	return names, err
+}
+
+func GetDataFieldFromSecret(secret *coreV1.Secret, field_name string) (string, error) {
+	common.Debugf("Retrieving '%s' data field from %s in namespace %s",
+		field_name, secret.ObjectMeta.Name, secret.ObjectMeta.Namespace)
+	fieldBytes, keyFound := secret.Data[field_name]
+	if !keyFound {
+		return "", fmt.Errorf("No '%s' data field found in Kubernetes secret %s in %s namespace",
+			field_name, secret.ObjectMeta.Name, secret.ObjectMeta.Namespace)
+	} else if len(fieldBytes) == 0 {
+		return "", fmt.Errorf("Value for %s is an empty string", field_name)
+	}
+	return strings.TrimSpace(string(fieldBytes)), nil
+}
+
+// Given a namespace and a name, returns the matching secret
+func GetSecret(namespace, name string) (*coreV1.Secret, error) {
+	common.Debugf("Retrieving kubernetes secret %s in %s namespace", name, namespace)
+	clientset, err := GetClientset()
+	if err != nil {
+		return nil, err
+	}
+	return clientset.CoreV1().Secrets(namespace).Get(
+		context.TODO(),
+		name,
+		v1.GetOptions{},
+	)
+}
+
+func GetSecretDataField(namespace, name, field_name string) (string, error) {
+	k8sSecret, err := GetSecret(namespace, name)
+	if err != nil {
+		return "", err
+	}
+	return GetDataFieldFromSecret(k8sSecret, field_name)
 }
 
 // Given a namespace and name, returns the matching configmap

--- a/cmsdev/redact_cmsdev_log.py
+++ b/cmsdev/redact_cmsdev_log.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+"""
+Redact credentials that were overzealously logged by prior cmsdev versions
+"""
+
+import os
+import shutil
+import tempfile
+
+LOGDIR="/opt/cray/tests/install/logs/cmsdev"
+LOGPATH=os.path.join(LOGDIR, "cmsdev.log")
+
+class CommandLine:
+    def __init__(self, pattern, delete_line=True, delete_output=True):
+        self.pattern = pattern
+        self.delete_line = delete_line
+        self.delete_output = delete_output
+
+REMOVE_LINES = [
+    'vcs username (base 64) = ',
+    'Decoded vcs username = ',
+    'vcs password (base 64) = ',
+    'Decoded vcs password = ' ]
+
+RUN_COMMAND = ' msg="Running command: ' 
+COMMAND_OUTPUT = ' msg="Command output: '
+
+COMMAND_LINES = [
+    CommandLine(' | base64 -d'),
+    CommandLine('kubectl get secret -n services vcs-user-credentials', delete_line=False),
+    CommandLine('kubectl get secrets admin-client-auth',  delete_line=False),
+    CommandLine('curl -k -s -d grant_type=client_credentials', delete_output=False)
+]
+
+def scan_line(logline, remove_command_output):
+    """
+    Returns a tuple of remove_line, remove_command_output
+    """
+    remove_line = False
+    if remove_command_output:
+        remove_command_output = False
+        if COMMAND_OUTPUT in logline:
+            # Remove this line
+            remove_line = True
+    remove_line = remove_line or any(pattern in logline for pattern in REMOVE_LINES)
+    for cmdline in COMMAND_LINES:
+        if cmdline.pattern in logline:
+            remove_line = remove_line or cmdline.delete_line
+            remove_command_output = remove_command_output or cmdline.delete_output
+    return remove_line, remove_command_output
+
+def main():
+    if not os.path.isfile(LOGPATH):
+        return
+    remove_command_output = False
+    tmpfilepath = tempfile.mkstemp(dir=LOGDIR)[1]
+    with open(LOGPATH, "rt") as logfile:
+        with open(tmpfilepath, "wt") as tmpfile:
+            for logline in logfile:
+                remove_line, remove_command_output = scan_line(logline, remove_command_output)
+                if not remove_line:
+                    tmpfile.write(logline)
+    # Copy over original log file
+    shutil.copyfile(tmpfilepath, LOGPATH)
+    # Remove temporary file
+    os.remove(tmpfilepath)
+
+if __name__ == "__main__":
+    main()

--- a/cray-cmstools-crayctldeploy.spec
+++ b/cray-cmstools-crayctldeploy.spec
@@ -63,6 +63,9 @@ echo /usr/local/bin | tee -a INSTALLED_FILES
 install -m 755 cmsdev/bin/cmsdev %{buildroot}/usr/local/bin/cmsdev
 echo /usr/local/bin/cmsdev | tee -a INSTALLED_FILES
 
+install -m 755 cmsdev/redact_cmsdev_log.py %{buildroot}/usr/local/bin/redact_cmsdev_log.py
+echo /usr/local/bin/redact_cmsdev_log.py | tee -a INSTALLED_FILES
+
 # Log directory for cmsdev
 install -m 755 -d %{buildroot}%{cmsdev_logdir}
 echo %{cmsdev_logdir} | tee -a INSTALLED_FILES
@@ -95,6 +98,10 @@ install -m 755 run_barebones_image_test.sh %{buildroot}/opt/cray/tests/integrati
 echo /opt/cray/tests/integration/csm/barebones_image_test | tee -a INSTALLED_FILES
 
 cat INSTALLED_FILES | xargs -i sh -c 'test -L $RPM_BUILD_ROOT{} -o -f $RPM_BUILD_ROOT{} && echo {} || echo %dir {}' | sort -u > FILES
+
+%post
+# Redact any credentials that were logged by earlier cmsdev versions
+/usr/local/bin/redact_cmsdev_log.py
 
 %clean
 


### PR DESCRIPTION
There are a few ways in which cmsdev does a bad job with credentials:
1. It uses some of them by running commands whose arguments contain credentials, and whose arguments could be seen by running "ps -ef" on the system.
2. It includes some of them in the cmsdev log

This ticket takes care of both of those things.