### PR TITLE
CASMTRIAGE-7245: barebones test: Follow now-enforced API spec when creating BOS session template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.23.1] - 2024-08-27
 
+### Added
+- barebones image test: Improved logging of API calls
+
 ### Fixed
 - barebones image test: Remove `rootfs_provider` and `rootfs_provider_passthrough` fields from
   session template that is created. They are set to empty strings, and this is not legal under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.1] - 2024-08-27
+
+### Fixed
+- barebones image test: Remove `rootfs_provider` and `rootfs_provider_passthrough` fields from
+  session template that is created. They are set to empty strings, and this is not legal under
+  the now-enforced (starting in CSM 1.6) API spec.
+
 ## [1.23.0] - 2024-08-26
 
 ### Dependencies

--- a/barebones_image_test/api/api.py
+++ b/barebones_image_test/api/api.py
@@ -78,9 +78,15 @@ def request(verb, url, headers=None, add_auth_header=True, verify=SYSTEM_CA_CERT
     Automatically adds API auth to header, if specified.
     """
     if add_auth_header:
-        if not headers:
+        logger.debug("API %s request to %s with args: %s", verb, url, kwargs)
+        if headers:
+            logger.debug("headers: %s", headers)
+        else:
             headers = {}
         add_api_auth(headers)
+    else:
+        # We don't want the client_secret to be logged
+        logger.debug("API %s request to %s (args not logged)", verb, url)
     session = requests_retry_session()
     try:
         return session.request(verb, url=url, headers=headers, verify=verify, **kwargs)

--- a/barebones_image_test/bos/bos_template.py
+++ b/barebones_image_test/bos/bos_template.py
@@ -69,8 +69,6 @@ class BosTemplate(TestResource):
             "kernel_parameters": kernel_parameters,
             "node_roles_groups": ["Compute"],
             "path": ims_image.s3_path,
-            "rootfs_provider": "",
-            "rootfs_provider_passthrough": "",
             "type": "s3" }
 
         bos_params = {

--- a/barebones_image_test/test_resource.py
+++ b/barebones_image_test/test_resource.py
@@ -75,7 +75,4 @@ class TestResource(ABC):
         """
         Calls the API to get data on this resource
         """
-        logger.debug("Making API GET query for %s (URL=%s)", self.label_and_name, self.url)
-        resp_json = request_and_check_status("get", self.url, expected_status=200, parse_json=True)
-        logger.debug("Completed API GET query for %s: %s", self.label_and_name, resp_json)
-        return resp_json
+        return request_and_check_status("get", self.url, expected_status=200, parse_json=True)


### PR DESCRIPTION
The barebones test creates a BOS session template, and it specifies empty strings in the boot set for the `rootfs_provider` and `rootfs_provider_passthrough` fields. These are not required fields for boot sets, but if they are specified, they cannot be empty strings. Previously this restriction was stated in the API spec text but not enforced. Starting in CSM 1.6, it is being enforced, and it caused the barebones test to fail.

This PR modifies the test so that it does not include these fields in the boot set of the session template it is creating.

It also improves the logging of the API calls being by the test (since I noticed the log file doesn't include most of these).

I tested this on fanta (where the problem was reported) and verified that it works.