### PR TITLE
CASMTRIAGE-7440: cmsdev: Do not fail BOS test for unsuccessful migration pods if there is also a successful one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.1] - 2024-10-25
+
+### Fixed
+- cmsdev: BOS test should pass if there are no cray-bos-migration pods, or if at least one
+  of them Succeeded. In other words, it should only fail if there are one or more
+  cray-bos-migration pods, and none of them Succeeded. This is because during an upgrade,
+  the initial migration pods may fail because the BOS database is not yet ready. As long
+  as the migration job eventually succeeded, we do not care about the initial failures.
+
 ## [1.24.0] - 2024-09-03
 
 ### Changed


### PR DESCRIPTION
When BOS is upgraded, it creates a migration job, The first pod this job creates may fail if the BOS database is taking a while to get updated. In this case, the cmsdev test fails, because it currently fails when it sees any migration pod that is not successful. This PR changes it so that it does not fail when there are unsuccessful migration pods, provided there is also a successful one.

I have tested this on mug and verified that if there are no migration pods, or a failed pod and a successful one, then the test passes. I also verified that if there is only an unsuccessful migration pod, then the test fails.