### PR TITLE
CASMCMS-9181: Capture insatlled RPM versions during cmsdev test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9181: cmsdev Should record installed version of Cray CLI RPM
+- CASMCMS-9328: IMS: Store Artifact logs after signing key test failure
+
 ## [1.27.0] - 2025-02-03
 
 ### Dependencies

--- a/cmsdev/internal/cmd/test.go
+++ b/cmsdev/internal/cmd/test.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -31,6 +31,10 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/spf13/cobra"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/test/bos"
@@ -39,9 +43,6 @@ import (
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/test/ims"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/test/ipxe_tftp"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/test/vcs"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // Test timeouts (in seconds)
@@ -196,7 +197,10 @@ func RunTests(services []string, retry bool, noclean bool) (passed, failed []str
 		}
 		common.UnsetTestService()
 	}
-
+	// Capture OS specific information after test failure.
+	if len(failed) > 0 {
+		common.ArtifactGetAdditionalInfo()
+	}
 	// Compress test artifacts, if any
 	common.CompressArtifacts()
 	return

--- a/cmsdev/internal/lib/common/printlog.go
+++ b/cmsdev/internal/lib/common/printlog.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -34,13 +34,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	c "github.com/fatih/color"
-	"github.com/sirupsen/logrus"
-	resty "gopkg.in/resty.v1"
 	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	c "github.com/fatih/color"
+	"github.com/sirupsen/logrus"
+	resty "gopkg.in/resty.v1"
 )
 
 // The following line is also used by the Makefile and RPM spec file in this repo. Any changes to it
@@ -396,5 +397,8 @@ func CreateLogFile(path, version string, logs, retry, quiet, verbose bool) {
 	testLog = logFile.WithFields(logrus.Fields{"version": version, "args": strings.Join(args, ",")})
 	logFileDir = path
 	Infof("cmsdev starting")
+	for _, pkg := range RPMLIST {
+		Debugf("%s version: %s", pkg, GetPackageVersion(pkg))
+	}
 	fmt.Printf("Starting main run, version: %s, tag: %s\n", version, runTag)
 }

--- a/cmsdev/internal/test/cfs/cfs.go
+++ b/cmsdev/internal/test/cfs/cfs.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -30,10 +30,11 @@ package cfs
 
 import (
 	"regexp"
+	"strings"
+
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
-	"strings"
 )
 
 func IsCFSRunning() (passed bool) {

--- a/cmsdev/internal/test/ims/ims.go
+++ b/cmsdev/internal/test/ims/ims.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -304,6 +304,10 @@ func IsIMSRunning() (passed bool) {
 		}
 	}
 
+	if !signingkeysTest() {
+		passed = false
+	}
+
 	if !passed && !artifactsCollected {
 		common.ArtifactsKubernetes()
 		if len(podNames) > 0 {
@@ -313,10 +317,6 @@ func IsIMSRunning() (passed bool) {
 			common.ArtifactDescribeNamespacePods(common.NAMESPACE, pvcNames)
 		}
 		artifactsCollected = true
-	}
-
-	if !signingkeysTest() {
-		passed = false
 	}
 
 	return


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
CASMCMS-9181: cmsdev Should record installed version of Cray CLI RPM
CASMCMS-9328: IMS: Store Artifact logs after signing key test failure
_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:
it was tested on mug

- Artifact tar created after signing key test failed.

Following lines added to the  log file at the start of the test 

```
time="2025-03-14T20:08:27.473293036Z" level=debug msg="craycli version: craycli-0.83.4-1.x86_64" args=quiet run=YDJGJ service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.28.0
time="2025-03-14T20:08:27.485861576Z" level=error msg="Error getting docs-csm version: exit status 1\n" args=quiet run=YDJGJ service= src="cmsdev/internal/lib/common/common.go:183" version=1.28.0
time="2025-03-14T20:08:27.485936301Z" level=debug msg="docs-csm version: " args=quiet run=YDJGJ service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.28.0
time="2025-03-14T20:08:27.502829476Z" level=debug msg="csm-testing version: csm-testing-1.18.7~7~g5212858-1.noarch" args=quiet run=YDJGJ service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.28.0
time="2025-03-14T20:08:27.512076383Z" level=debug msg="goss-servers version: goss-servers-1.18.7~7~g5212858-1.noarch" args=quiet run=YDJGJ service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.28.0
```
Also in case of failure a new file is create with "rpm -qa" output

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

