### PR TITLE
Build cmsdev using Golang 1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Build `cmsdev` using Golang 1.23 (up from 1.20)
+
 ### Dependencies
 - Bump `dangoslen/dependabot-changelog-helper` from 3 to 4 ([#243](https://github.com/Cray-HPE/cms-tools/pull/243))
 

--- a/cmsdev/go.mod
+++ b/cmsdev/go.mod
@@ -1,4 +1,4 @@
-// Copyright 2021, 2023 Hewlett Packard Enterprise Development LP
+// Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -22,7 +22,7 @@
 
 module stash.us.cray.com/SCMS/cms-tools/cmsdev
 
-go 1.20
+go 1.23
 
 require (
 	github.com/fatih/color v1.17.0


### PR DESCRIPTION
This is necessary in order to resolve some security vulnerabilities.