### PR TITLE
CASMCMS-9384, CASMCMS-9379: IMS cmsdev Test v2 API and default version API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - CASMCMS-8135: IMS: cmsdev failed during post-install health check
+- CASMCMS-9384: cmsdev should warn if docs-csm RPM is not installed
 
 ## [1.29.0] - 2025-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9379: TESTS: IMS: cmsdev: Test v2 API and default version API
+
 ### Fixed
 - CASMCMS-8135: IMS: cmsdev failed during post-install health check
 

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -48,6 +48,15 @@ const BASEURL = "https://" + BASEHOST
 const LOCALHOST = "http://localhost:5000"
 const NAMESPACE string = "services"
 
+// List of API versions supported by the IMS service
+var IMSAPIVERSIONS = []string{
+	"v2",
+	"v3",
+}
+
+// variable to dynamically set the API version to be used in the tests
+var imsAPIVersions string = ""
+
 // List of RPMs version captured at the start of the test. In case of failure, rpm -qa will be captured.
 var RPMLIST = []string{
 	"craycli",
@@ -67,6 +76,7 @@ type endpointMethod struct {
 type Endpoint struct {
 	Methods map[string]*endpointMethod // endpoint METHOD data
 	Url     string                     // url string appended to base to reach endpoint
+	Uri     string                     // uri string appended to base to reach endpoint
 	Version string                     `default:"v1"` // endpoint version
 }
 
@@ -148,6 +158,15 @@ var runStartTimes []time.Time
 
 var artifactDirectory, artifactFilePrefix string
 var artifactDirectoryCreated, artifactsLogged bool
+
+func SetIMSAPIVersion(version string) {
+	// Set the API version to be used in the tests
+	imsAPIVersions = version
+}
+func GetIMSAPIVersion() string {
+	// Get the API version to be used in the tests
+	return imsAPIVersions
+}
 
 // Set and unset the run sub-tag
 func SetRunSubTag(tag string) {
@@ -348,7 +367,8 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 			"POST":   newMethodEndpoint("", "Create an image record", []int{201, 400, 422, 500}),
 			"PATCH":  newMethodEndpoint("", "Update an image record", []int{200, 400, 404, 409, 422, 500}),
 		},
-		Url:     "/apis/ims/v3/images",
+		Url:     "/apis/ims",
+		Uri:     "/images",
 		Version: "v2",
 	}
 	endpoints["ims"]["jobs"] = &Endpoint{
@@ -366,7 +386,8 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 			"GET":    newMethodEndpoint("", "Retrieve all public key records", []int{200, 500}),
 			"POST":   newMethodEndpoint("", "Create a public key record", []int{201, 400, 422, 500}),
 		},
-		Url:     "/apis/ims/v3/public-keys",
+		Url:     "/apis/ims",
+		Uri:     "/public-keys",
 		Version: "v2",
 	}
 	// The status codes for these recipes IMS endpoints don't match the IMS openapi spec currently,
@@ -378,7 +399,8 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 			"POST":   newMethodEndpoint("", "Create a recipe record", []int{201, 400, 422, 500}),
 			"PATCH":  newMethodEndpoint("", "Update a recipe record", []int{200, 400, 404, 409, 422, 500}),
 		},
-		Url:     "/apis/ims/v3/recipes",
+		Url:     "/apis/ims",
+		Uri:     "/recipes",
 		Version: "v2",
 	}
 	endpoints["ims"]["version"] = &Endpoint{

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -729,6 +729,13 @@ func CompareMaps(a, b map[string]string) bool {
 	return true
 }
 
+func PrintLog(msg string) {
+	msglen := len(msg)
+	Infof("%s", strings.Repeat("*", msglen+4))
+	Infof("* %s *", msg)
+	Infof("%s", strings.Repeat("*", msglen+4))
+}
+
 func init() {
 	// Set default values
 	runStartTimes = append(runStartTimes, time.Now())

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -200,7 +200,7 @@ func GetPackageVersion(packageName string) string {
 	cmd := exec.Command("rpm", "-q", packageName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		Errorf("Error getting %s version: %v\n", packageName, err)
+		Warnf("Package %s not installed", packageName)
 		return ""
 	}
 	installedPkg := strings.TrimSpace(string(output))

--- a/cmsdev/internal/test/ims/ims.go
+++ b/cmsdev/internal/test/ims/ims.go
@@ -181,7 +181,7 @@ func IsIMSRunning() (passed bool) {
 	}
 
 	// Verify that we can perform CRUD operation on image via API
-	if !TestImageCRUDOperation() {
+	if !TestImageCRUDOperationUsingAPIVersions() {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/ims/ims.go
+++ b/cmsdev/internal/test/ims/ims.go
@@ -162,7 +162,7 @@ func IsIMSRunning() (passed bool) {
 	}
 
 	// Verify recipe CRUD operations via API
-	if !TestRecipeCRUDOperation() {
+	if !TestRecipeCRUDOperationUsingAPIVersions() {
 		passed = false
 	}
 
@@ -201,7 +201,7 @@ func IsIMSRunning() (passed bool) {
 	}
 
 	// Verify that we can perform CRUD operation on public key via API
-	if !TestPublicKeyCRUDOperation() {
+	if !TestPublicKeyCRUDOperationUsingAPIVersions() {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/ims/ims_images_api.go
+++ b/cmsdev/internal/test/ims/ims_images_api.go
@@ -314,3 +314,17 @@ func constructIMSURL(endpoint, apiVersion string) string {
 	}
 	return base + "/" + endpoints["ims"][endpoint].Uri
 }
+
+func GetCreateImageExpectedMetadata(metadata map[string]string) map[string]string {
+	// Create expected metadata for the image
+	apiVersion := common.GetIMSAPIVersion()
+
+	if apiVersion == "v2" {
+		return metadata
+	} else {
+		expectedMetadata := map[string]string{
+			metadata["key"]: metadata["value"],
+		}
+		return expectedMetadata
+	}
+}

--- a/cmsdev/internal/test/ims/ims_images_api.go
+++ b/cmsdev/internal/test/ims/ims_images_api.go
@@ -312,7 +312,7 @@ func constructIMSURL(endpoint, apiVersion string) string {
 	if apiVersion != "" {
 		return base + "/" + apiVersion + endpoints["ims"][endpoint].Uri
 	}
-	return base + "/" + endpoints["ims"][endpoint].Uri
+	return base + endpoints["ims"][endpoint].Uri
 }
 
 func VerifyIMSImageRecord(imageRecord IMSImageRecord, expectedImageRecord IMSImageRecord) (ok bool) {

--- a/cmsdev/internal/test/ims/ims_images_api.go
+++ b/cmsdev/internal/test/ims/ims_images_api.go
@@ -56,8 +56,8 @@ func CreateIMSImageRecordAPI(imageName string, metadata map[string]string) (imag
 	}
 
 	params.JsonStr = string(jsonPayload)
-	apiversion := common.GetIMSAPIVersion()
-	url = constructIMSURL("images", apiversion)
+	apiVersion := common.GetIMSAPIVersion()
+	url = constructIMSURL("images", apiVersion)
 	resp, err := test.RestfulVerifyStatus("POST", url, *params, http.StatusCreated)
 	if err != nil {
 		common.Error(err)
@@ -94,8 +94,8 @@ func UpdateIMSImageRecordAPI(imageId string, arch string, metadata map[string]st
 	}
 
 	params.JsonStrArray = jsonPayload
-	apiversion := common.GetIMSAPIVersion()
-	url := constructIMSURL("images", apiversion) + "/" + imageId
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("images", apiVersion) + "/" + imageId
 	resp, err := test.RestfulVerifyStatus("PATCH", url, *params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
@@ -119,8 +119,8 @@ func DeleteIMSImageRecordAPI(imageId string) (ok bool) {
 		return
 	}
 
-	apiversion := common.GetIMSAPIVersion()
-	url := constructIMSURL("images", apiversion) + "/" + imageId
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("images", apiVersion) + "/" + imageId
 	// setting the payload
 	_, err := test.RestfulVerifyStatus("DELETE", url, *params, http.StatusNoContent)
 	if err != nil {
@@ -150,8 +150,8 @@ func UndeleteIMSImageRecordAPI(imageId string) (ok bool) {
 	}
 	params.JsonStrArray = jsonPayload
 
-	apiversion := common.GetIMSAPIVersion()
-	baseURL := constructIMSURL("images", apiversion)
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("images", apiVersion)
 	// getting the base uri needed for undelete
 	uri := strings.Split(baseURL, "/images")
 	url := uri[0] + "/deleted/images" + "/" + imageId
@@ -172,8 +172,8 @@ func PermanentDeleteIMSImageRecordAPI(imageId string) (ok bool) {
 		return
 	}
 
-	apiversion := common.GetIMSAPIVersion()
-	baseURL := constructIMSURL("images", apiversion)
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("images", apiVersion)
 	// getting the base uri needed for Permanent delete
 	uri := strings.Split(baseURL, "/images")
 	url := uri[0] + "/deleted/images" + "/" + imageId
@@ -194,8 +194,8 @@ func GetDeletedIMSImageRecordAPI(imageId string, httpStatus int) (imageRecord IM
 		return IMSImageRecord{}, false
 	}
 
-	apiversion := common.GetIMSAPIVersion()
-	baseURL := constructIMSURL("images", apiversion)
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("images", apiVersion)
 	// getting the base uri needed for getting deleted image record
 	uri := strings.Split(baseURL, "/images")
 	url := uri[0] + "/deleted/images" + "/" + imageId
@@ -222,8 +222,8 @@ func GetDeletedIMSImageRecordsAPI() (recordList []IMSImageRecord, ok bool) {
 		return []IMSImageRecord{}, false
 	}
 
-	apiversion := common.GetIMSAPIVersion()
-	baseURL := constructIMSURL("images", apiversion)
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("images", apiVersion)
 	// getting the base uri needed for getting deleted image records
 	uri := strings.Split(baseURL, "/images")
 	url := uri[0] + "/deleted/images"
@@ -251,8 +251,8 @@ func GetIMSImageRecordAPI(imageId string, httpStatus int) (imageRecord IMSImageR
 		return IMSImageRecord{}, false
 	}
 
-	apiversion := common.GetIMSAPIVersion()
-	url := constructIMSURL("images", apiversion) + "/" + imageId
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("images", apiVersion) + "/" + imageId
 	resp, err := test.RestfulVerifyStatus("GET", url, *params, httpStatus)
 	if err != nil {
 		common.Error(err)
@@ -278,8 +278,8 @@ func GetIMSImageRecordsAPI() (recordList []IMSImageRecord, ok bool) {
 		return []IMSImageRecord{}, false
 	}
 
-	apiversion := common.GetIMSAPIVersion()
-	url := constructIMSURL("images", apiversion)
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("images", apiVersion)
 	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
@@ -313,4 +313,31 @@ func constructIMSURL(endpoint, apiVersion string) string {
 		return base + "/" + apiVersion + endpoints["ims"][endpoint].Uri
 	}
 	return base + "/" + endpoints["ims"][endpoint].Uri
+}
+
+func VerifyIMSImageRecord(imageRecord IMSImageRecord, expectedImageRecord IMSImageRecord) (ok bool) {
+	// Verify the image record is not empty
+	ok = true
+	if imageRecord.Id != expectedImageRecord.Id {
+		common.Errorf("Image ID %s does not match expected ID %s", imageRecord.Id, expectedImageRecord.Id)
+		ok = false
+	}
+
+	// Verify the image record is in the list of images
+	if imageRecord.Name != expectedImageRecord.Name {
+		common.Errorf("Expected image name %s, got %s", expectedImageRecord.Name, imageRecord.Name)
+		ok = false
+	}
+
+	if !common.CompareMaps(imageRecord.Metadata, expectedImageRecord.Metadata) {
+		common.Errorf("Expected metadata %v, got %v", expectedImageRecord.Metadata, imageRecord.Metadata)
+		ok = false
+	}
+
+	if imageRecord.Arch != expectedImageRecord.Arch {
+		common.Errorf("Expected image arch %s, got %s", expectedImageRecord.Arch, imageRecord.Arch)
+		ok = false
+	}
+
+	return
 }

--- a/cmsdev/internal/test/ims/ims_images_api.go
+++ b/cmsdev/internal/test/ims/ims_images_api.go
@@ -314,17 +314,3 @@ func constructIMSURL(endpoint, apiVersion string) string {
 	}
 	return base + "/" + endpoints["ims"][endpoint].Uri
 }
-
-func GetCreateImageExpectedMetadata(metadata map[string]string) map[string]string {
-	// Create expected metadata for the image
-	apiVersion := common.GetIMSAPIVersion()
-
-	if apiVersion == "v2" {
-		return metadata
-	} else {
-		expectedMetadata := map[string]string{
-			metadata["key"]: metadata["value"],
-		}
-		return expectedMetadata
-	}
-}

--- a/cmsdev/internal/test/ims/ims_public_key_api.go
+++ b/cmsdev/internal/test/ims/ims_public_key_api.go
@@ -42,8 +42,13 @@ func GetDeletedIMSPublicKeyRecordAPI(publicKeyId string, httpStatus int) (public
 	if params == nil {
 		return
 	}
-	uri := strings.Split(endpoints["ims"]["public_keys"].Url, "/public-keys")
-	url := common.BASEURL + uri[0] + "/deleted/public-keys" + "/" + publicKeyId
+
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("public_keys", apiVersion)
+	// getting the base uri needed for getting all deleted public key records
+	uri := strings.Split(baseURL, "/public-keys")
+	url := uri[0] + "/deleted/public-keys" + "/" + publicKeyId
+
 	resp, err := test.RestfulVerifyStatus("GET", url, *params, httpStatus)
 	if err != nil {
 		common.Error(err)
@@ -67,8 +72,13 @@ func GetDeletedIMSPublicKeyRecordsAPI() (recordList []IMSPublicKeyRecord, ok boo
 	if params == nil {
 		return
 	}
-	uri := strings.Split(endpoints["ims"]["public_keys"].Url, "/public-keys")
-	url := common.BASEURL + uri[0] + "/deleted/public-keys"
+
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("public_keys", apiVersion)
+	// getting the base uri needed for getting all deleted public key records
+	uri := strings.Split(baseURL, "/public-keys")
+	url := uri[0] + "/deleted/public-keys"
+
 	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
 	if err != nil {
 		common.Error(err)
@@ -92,7 +102,10 @@ func DeleteIMSPublicKeyRecordAPI(publicKeyId string) (ok bool) {
 	if params == nil {
 		return
 	}
-	url := common.BASEURL + endpoints["ims"]["public_keys"].Url + "/" + publicKeyId
+
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("public_keys", apiVersion) + "/" + publicKeyId
+
 	_, err := test.RestfulVerifyStatus("DELETE", url, *params, http.StatusNoContent)
 	if err != nil {
 		common.Error(err)
@@ -122,8 +135,12 @@ func UndeleteIMSPublicKeyRecordAPI(publicKeyId string) (ok bool) {
 	}
 	params.JsonStrArray = jsonPayload
 
-	uri := strings.Split(endpoints["ims"]["public_keys"].Url, "/public-keys")
-	url := common.BASEURL + uri[0] + "/deleted/public-keys" + "/" + publicKeyId
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("public_keys", apiVersion)
+	// getting the base uri needed for restoring deleted public key records
+	uri := strings.Split(baseURL, "/public-keys")
+	url := uri[0] + "/deleted/public-keys" + "/" + publicKeyId
+
 	_, err = test.RestfulVerifyStatus("PATCH", url, *params, http.StatusNoContent)
 	if err != nil {
 		common.Error(err)
@@ -140,8 +157,13 @@ func PermanentDeleteIMSPublicKeyRecordAPI(publicKeyId string) (ok bool) {
 	if params == nil {
 		return
 	}
-	uri := strings.Split(endpoints["ims"]["public_keys"].Url, "/public-keys")
-	url := common.BASEURL + uri[0] + "/deleted/public-keys" + "/" + publicKeyId
+
+	apiVersion := common.GetIMSAPIVersion()
+	baseURL := constructIMSURL("public_keys", apiVersion)
+	// getting the base uri needed for getting all deleted public key records
+	uri := strings.Split(baseURL, "/public-keys")
+	url := uri[0] + "/deleted/public-keys" + "/" + publicKeyId
+
 	_, err := test.RestfulVerifyStatus("DELETE", url, *params, http.StatusNoContent)
 	if err != nil {
 		common.Error(err)
@@ -178,7 +200,10 @@ func CreateIMSPublicKeyRecordAPI(publicKeyName string) (publicKeyRecord IMSPubli
 	}
 
 	params.JsonStr = string(jsonPayload)
-	url := common.BASEURL + endpoints["ims"]["public_keys"].Url
+
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("public_keys", apiVersion)
+
 	resp, err := test.RestfulVerifyStatus("POST", url, *params, http.StatusCreated)
 	if err != nil {
 		common.Error(err)
@@ -203,7 +228,10 @@ func GetIMSPublicKeyRecordAPI(pkeyId string, httpStatus int) (pkeyRecord IMSPubl
 	if params == nil {
 		return IMSPublicKeyRecord{}, false
 	}
-	url := common.BASEURL + endpoints["ims"]["public_keys"].Url + "/" + pkeyId
+
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("public_keys", apiVersion) + "/" + pkeyId
+
 	resp, err := test.RestfulVerifyStatus("GET", url, *params, httpStatus)
 	if err != nil {
 		common.Error(err)
@@ -228,7 +256,10 @@ func GetIMSPublicKeyRecordsAPI() (recordList []IMSPublicKeyRecord, ok bool) {
 	if params == nil {
 		return
 	}
-	url := common.BASEURL + endpoints["ims"]["public_keys"].Url
+
+	apiVersion := common.GetIMSAPIVersion()
+	url := constructIMSURL("public_keys", apiVersion)
+
 	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
 	if err != nil {
 		common.Error(err)

--- a/cmsdev/internal/test/ims/verify_ims_images.go
+++ b/cmsdev/internal/test/ims/verify_ims_images.go
@@ -59,9 +59,13 @@ func TestImageCRUDOperation(apiVersion string) (passed bool) {
 		return false
 	}
 
+	// Test updating the image
+	updated := TestImageUpdate(imageRecord.Id)
+
+	// Test get all images
+	getAll := TestGetAllImages()
+
 	if apiVersion == "v3" {
-		// Test updating the image
-		updated := TestImageUpdate(imageRecord.Id)
 
 		// Test soft deleting the image
 		deleted := TestImageDelete(imageRecord.Id)
@@ -72,21 +76,13 @@ func TestImageCRUDOperation(apiVersion string) (passed bool) {
 		// Test hard deleting the image
 		permDeleted := TestImagePermanentDelete(imageRecord.Id)
 
-		// Test get all images
-		getAll := TestGetAllImages()
-
 		return updated && deleted && undeleted && permDeleted && getAll
-	} else {
-		// Test updating the image
-		updated := TestImageUpdate(imageRecord.Id)
-
-		// Test deleting the image
-		deleted := TestImageDeleteV2(imageRecord.Id)
-
-		getAll := TestGetAllImages()
-
-		return updated && deleted && getAll
 	}
+
+	// Test deleting the image
+	deleted := TestImageDeleteV2(imageRecord.Id)
+
+	return updated && deleted && getAll
 }
 
 func TestImagePermanentDelete(imageId string) (passed bool) {

--- a/cmsdev/internal/test/ims/verify_ims_images.go
+++ b/cmsdev/internal/test/ims/verify_ims_images.go
@@ -22,6 +22,7 @@
 package ims
 
 import (
+	"fmt"
 	"net/http"
 
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
@@ -39,14 +40,14 @@ func TestImageCRUDOperationUsingAPIVersions() (passed bool) {
 	passed = true
 
 	for _, version := range common.IMSAPIVERSIONS {
-		common.Infof("Testing image CRUD operations using API version: %s", version)
+		common.PrintLog(fmt.Sprintf("Testing image CRUD operations using API version: %s", version))
 		common.SetIMSAPIVersion(version)
 		passed = passed && TestImageCRUDOperation(version)
 	}
 
 	// default API version
 	common.SetIMSAPIVersion("")
-	common.Infof("Testing image CRUD operations using default API version")
+	common.PrintLog("Testing image CRUD operations using default API version")
 	passed = passed && TestImageCRUDOperation(common.GetIMSAPIVersion())
 	return passed
 }
@@ -58,19 +59,7 @@ func TestImageCRUDOperation(apiVersion string) (passed bool) {
 		return false
 	}
 
-	if apiVersion == "v2" {
-
-		// Test updating the image
-		updated := TestImageUpdate(imageRecord.Id)
-
-		// Test deleting the image
-		deleted := TestImageDeleteV2(imageRecord.Id)
-
-		getAll := TestGetAllImages()
-
-		return updated && deleted && getAll
-
-	} else {
+	if apiVersion == "v3" {
 		// Test updating the image
 		updated := TestImageUpdate(imageRecord.Id)
 
@@ -87,6 +76,16 @@ func TestImageCRUDOperation(apiVersion string) (passed bool) {
 		getAll := TestGetAllImages()
 
 		return updated && deleted && undeleted && permDeleted && getAll
+	} else {
+		// Test updating the image
+		updated := TestImageUpdate(imageRecord.Id)
+
+		// Test deleting the image
+		deleted := TestImageDeleteV2(imageRecord.Id)
+
+		getAll := TestGetAllImages()
+
+		return updated && deleted && getAll
 	}
 }
 

--- a/cmsdev/internal/test/ims/verify_ims_images.go
+++ b/cmsdev/internal/test/ims/verify_ims_images.go
@@ -235,9 +235,7 @@ func TestImageCreate() (imageRecord IMSImageRecord, passed bool) {
 		"key":   "name",
 		"value": imageName,
 	}
-	expectedMetadata := map[string]string{
-		"name": imageName,
-	}
+	expectedMetadata := GetCreateImageExpectedMetadata(metadata)
 
 	imageRecord, success := CreateIMSImageRecordAPI(imageName, metadata)
 	if !success || imageRecord.Id == "" {

--- a/cmsdev/internal/test/ims/verify_ims_images.go
+++ b/cmsdev/internal/test/ims/verify_ims_images.go
@@ -235,7 +235,9 @@ func TestImageCreate() (imageRecord IMSImageRecord, passed bool) {
 		"key":   "name",
 		"value": imageName,
 	}
-	expectedMetadata := GetCreateImageExpectedMetadata(metadata)
+	expectedMetadata := map[string]string{
+		metadata["key"]: metadata["value"],
+	}
 
 	imageRecord, success := CreateIMSImageRecordAPI(imageName, metadata)
 	if !success || imageRecord.Id == "" {

--- a/cmsdev/internal/test/ims/verify_ims_images_cli.go
+++ b/cmsdev/internal/test/ims/verify_ims_images_cli.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestImageCRUDOperationUsingCLI() (passed bool) {
+	common.PrintLog("Testing image CRUD operations using CLI")
 	// Test creating an image
 	imageRecord, success := TestCLIImageCreate()
 	if !success {

--- a/cmsdev/internal/test/ims/verify_ims_public_key.go
+++ b/cmsdev/internal/test/ims/verify_ims_public_key.go
@@ -59,6 +59,9 @@ func TestPublicKeyCRUDOperation(apiVersion string) (passed bool) {
 		return false
 	}
 
+	// Test get all public keys
+	getAll := TestGetAllPublicKeys()
+
 	if apiVersion == "v3" {
 		// Test soft deleting the public key
 		deleted := TestPublicKeyDelete(publicKeyRecord.Id)
@@ -69,19 +72,12 @@ func TestPublicKeyCRUDOperation(apiVersion string) (passed bool) {
 		// Test permanent deleting the public key
 		permDeleted := TestPublicKeyPermanentDelete(publicKeyRecord.Id)
 
-		// Test get all public keys
-		getAll := TestGetAllPublicKeys()
-
 		return deleted && undeleted && permDeleted && getAll
-	} else {
-		// Test deleting the public key
-		deleted := TestPublicKeyDeleteV2(publicKeyRecord.Id)
-
-		// Test get all public keys
-		getAll := TestGetAllPublicKeys()
-
-		return deleted && getAll
 	}
+	// Test deleting the public key
+	deleted := TestPublicKeyDeleteV2(publicKeyRecord.Id)
+
+	return deleted && getAll
 }
 
 func TestPublicKeyDelete(publicKeyId string) (passed bool) {

--- a/cmsdev/internal/test/ims/verify_ims_public_key.go
+++ b/cmsdev/internal/test/ims/verify_ims_public_key.go
@@ -22,6 +22,7 @@
 package ims
 
 import (
+	"fmt"
 	"net/http"
 
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
@@ -38,13 +39,13 @@ func TestPublicKeyCRUDOperationUsingAPIVersions() (passed bool) {
 	passed = true
 
 	for _, apiVersion := range common.IMSAPIVERSIONS {
-		common.Infof("Testing IMS Public Key CRUD operations using API version: %s", apiVersion)
+		common.PrintLog(fmt.Sprintf("Testing IMS Public Key CRUD operations using API version: %s", apiVersion))
 		common.SetIMSAPIVersion(apiVersion)
 		passed = passed && TestPublicKeyCRUDOperation(apiVersion)
 	}
 
 	// Test the default API version
-	common.Infof("Testing IMS Public Key CRUD operations using default API version.")
+	common.PrintLog("Testing IMS Public Key CRUD operations using default API version.")
 	common.SetIMSAPIVersion("")
 	passed = passed && TestPublicKeyCRUDOperation(common.GetIMSAPIVersion())
 
@@ -58,16 +59,7 @@ func TestPublicKeyCRUDOperation(apiVersion string) (passed bool) {
 		return false
 	}
 
-	if apiVersion == "v2" {
-		// Test deleting the public key
-		deleted := TestPublicKeyDeleteV2(publicKeyRecord.Id)
-
-		// Test get all public keys
-		getAll := TestGetAllPublicKeys()
-
-		return deleted && getAll
-	} else {
-
+	if apiVersion == "v3" {
 		// Test soft deleting the public key
 		deleted := TestPublicKeyDelete(publicKeyRecord.Id)
 
@@ -81,6 +73,14 @@ func TestPublicKeyCRUDOperation(apiVersion string) (passed bool) {
 		getAll := TestGetAllPublicKeys()
 
 		return deleted && undeleted && permDeleted && getAll
+	} else {
+		// Test deleting the public key
+		deleted := TestPublicKeyDeleteV2(publicKeyRecord.Id)
+
+		// Test get all public keys
+		getAll := TestGetAllPublicKeys()
+
+		return deleted && getAll
 	}
 }
 

--- a/cmsdev/internal/test/ims/verify_ims_public_key.go
+++ b/cmsdev/internal/test/ims/verify_ims_public_key.go
@@ -34,26 +34,54 @@ import (
  *
  */
 
-func TestPublicKeyCRUDOperation() (passed bool) {
+func TestPublicKeyCRUDOperationUsingAPIVersions() (passed bool) {
+	passed = true
+
+	for _, apiVersion := range common.IMSAPIVERSIONS {
+		common.Infof("Testing IMS Public Key CRUD operations using API version: %s", apiVersion)
+		common.SetIMSAPIVersion(apiVersion)
+		passed = passed && TestPublicKeyCRUDOperation(apiVersion)
+	}
+
+	// Test the default API version
+	common.Infof("Testing IMS Public Key CRUD operations using default API version.")
+	common.SetIMSAPIVersion("")
+	passed = passed && TestPublicKeyCRUDOperation(common.GetIMSAPIVersion())
+
+	return passed
+}
+
+func TestPublicKeyCRUDOperation(apiVersion string) (passed bool) {
 	// Test creating a public key
 	publicKeyRecord, success := TestPublicKeyCreate()
 	if !success {
 		return false
 	}
 
-	// Test soft deleting the public key
-	deleted := TestPublicKeyDelete(publicKeyRecord.Id)
+	if apiVersion == "v2" {
+		// Test deleting the public key
+		deleted := TestPublicKeyDeleteV2(publicKeyRecord.Id)
 
-	// Test undeleting the public key
-	undeleted := TestPublicKeyUndelete(publicKeyRecord.Id)
+		// Test get all public keys
+		getAll := TestGetAllPublicKeys()
 
-	// Test permanent deleting the public key
-	permDeleted := TestPublicKeyPermanentDelete(publicKeyRecord.Id)
+		return deleted && getAll
+	} else {
 
-	// Test get all public keys
-	getAll := TestGetAllPublicKeys()
+		// Test soft deleting the public key
+		deleted := TestPublicKeyDelete(publicKeyRecord.Id)
 
-	return deleted && undeleted && permDeleted && getAll
+		// Test undeleting the public key
+		undeleted := TestPublicKeyUndelete(publicKeyRecord.Id)
+
+		// Test permanent deleting the public key
+		permDeleted := TestPublicKeyPermanentDelete(publicKeyRecord.Id)
+
+		// Test get all public keys
+		getAll := TestGetAllPublicKeys()
+
+		return deleted && undeleted && permDeleted && getAll
+	}
 }
 
 func TestPublicKeyDelete(publicKeyId string) (passed bool) {
@@ -196,4 +224,30 @@ func TestPublicKeyCreate() (publicKeyRecord IMSPublicKeyRecord, passed bool) {
 
 	common.Infof("Public key %s was created with id %s", publicKeyName, publicKeyRecord.Id)
 	return publicKeyRecord, true
+}
+
+func TestPublicKeyDeleteV2(publicKeyId string) (passed bool) {
+	if success := DeleteIMSPublicKeyRecordAPI(publicKeyId); !success {
+		return false
+	}
+
+	// Verify the public key is not in the list of public keys
+	if _, success := GetIMSPublicKeyRecordAPI(publicKeyId, http.StatusNotFound); !success {
+		common.Errorf("Public key %s was not deleted", publicKeyId)
+		return false
+	}
+
+	// Verify the public key is not in the list of all public keys
+	publicKeyRecords, success := GetIMSPublicKeyRecordsAPI()
+	if !success {
+		return false
+	}
+
+	if PublicKeyRecordExists(publicKeyId, publicKeyRecords) {
+		common.Errorf("Public key %s was not deleted", publicKeyId)
+		return false
+	}
+
+	common.Infof("Public key %s successfully deleted", publicKeyId)
+	return true
 }

--- a/cmsdev/internal/test/ims/verify_ims_public_key_cli.go
+++ b/cmsdev/internal/test/ims/verify_ims_public_key_cli.go
@@ -31,6 +31,7 @@ import "stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
  */
 
 func TestPublicKeyCRUDOperationUsingCLI() (passed bool) {
+	common.PrintLog("Testing Public Key CRUD operations using CLI")
 	// Test creating a public key
 	publicKeyRecord, success := TestCLIPublicKeyCreate()
 	if !success {

--- a/cmsdev/internal/test/ims/verify_ims_recipes.go
+++ b/cmsdev/internal/test/ims/verify_ims_recipes.go
@@ -22,6 +22,7 @@
 package ims
 
 import (
+	"fmt"
 	"net/http"
 
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
@@ -37,14 +38,14 @@ import (
 func TestRecipeCRUDOperationUsingAPIVersions() (passed bool) {
 	passed = true
 	for _, apiVersion := range common.IMSAPIVERSIONS {
+		common.PrintLog(fmt.Sprintf("Testing recipe CRUD operations using IMS API version: %s", apiVersion))
 		common.SetIMSAPIVersion(apiVersion)
-		common.Infof("Testing recipe CRUD operations using IMS API version: %s", apiVersion)
 		passed = passed && TestRecipeCRUDOperation(apiVersion)
 	}
 
 	// Reset the IMS API version to the default value
 	common.SetIMSAPIVersion("")
-	common.Infof("Testing recipe CRUD operations using default API version")
+	common.PrintLog("Testing recipe CRUD operations using default API version")
 	passed = passed && TestRecipeCRUDOperation(common.GetIMSAPIVersion())
 	return passed
 }
@@ -56,19 +57,7 @@ func TestRecipeCRUDOperation(apiVersion string) (passed bool) {
 		return false
 	}
 
-	if apiVersion == "v2" {
-		// Test updating the recipe
-		updated := TestRecipeUpdate(recipeRecord.Id)
-
-		// Test deleting the recipe
-		deleted := TestRecipeDeleteV2(recipeRecord.Id)
-
-		//Test get all recipes
-		getAll := TestGetAllRecipes()
-
-		return updated && deleted && getAll
-
-	} else {
+	if apiVersion == "v3" {
 		// Test updating the recipe
 		updated := TestRecipeUpdate(recipeRecord.Id)
 
@@ -85,6 +74,17 @@ func TestRecipeCRUDOperation(apiVersion string) (passed bool) {
 		getAll := TestGetAllRecipes()
 
 		return updated && deleted && undeleted && permDeleted && getAll
+	} else {
+		// Test updating the recipe
+		updated := TestRecipeUpdate(recipeRecord.Id)
+
+		// Test deleting the recipe
+		deleted := TestRecipeDeleteV2(recipeRecord.Id)
+
+		//Test get all recipes
+		getAll := TestGetAllRecipes()
+
+		return updated && deleted && getAll
 	}
 }
 

--- a/cmsdev/internal/test/ims/verify_ims_recipes.go
+++ b/cmsdev/internal/test/ims/verify_ims_recipes.go
@@ -57,9 +57,13 @@ func TestRecipeCRUDOperation(apiVersion string) (passed bool) {
 		return false
 	}
 
+	// Test updating the recipe
+	updated := TestRecipeUpdate(recipeRecord.Id)
+
+	// Test get all recipes
+	getAll := TestGetAllRecipes()
+
 	if apiVersion == "v3" {
-		// Test updating the recipe
-		updated := TestRecipeUpdate(recipeRecord.Id)
 
 		// Test soft deleting the recipe
 		deleted := TestRecipeDelete(recipeRecord.Id)
@@ -70,22 +74,14 @@ func TestRecipeCRUDOperation(apiVersion string) (passed bool) {
 		// Test hard deleting the recipe
 		permDeleted := TestRecipePermanentDelete(recipeRecord.Id)
 
-		// Test get all recipes
-		getAll := TestGetAllRecipes()
-
 		return updated && deleted && undeleted && permDeleted && getAll
-	} else {
-		// Test updating the recipe
-		updated := TestRecipeUpdate(recipeRecord.Id)
-
-		// Test deleting the recipe
-		deleted := TestRecipeDeleteV2(recipeRecord.Id)
-
-		//Test get all recipes
-		getAll := TestGetAllRecipes()
-
-		return updated && deleted && getAll
 	}
+
+	// Test deleting the recipe
+	deleted := TestRecipeDeleteV2(recipeRecord.Id)
+
+	return updated && deleted && getAll
+
 }
 
 func TestRecipePermanentDelete(recipeId string) (passed bool) {

--- a/cmsdev/internal/test/ims/verify_ims_recipes.go
+++ b/cmsdev/internal/test/ims/verify_ims_recipes.go
@@ -34,28 +34,58 @@ import (
  *
  */
 
-func TestRecipeCRUDOperation() (passed bool) {
+func TestRecipeCRUDOperationUsingAPIVersions() (passed bool) {
+	passed = true
+	for _, apiVersion := range common.IMSAPIVERSIONS {
+		common.SetIMSAPIVersion(apiVersion)
+		common.Infof("Testing recipe CRUD operations using IMS API version: %s", apiVersion)
+		passed = passed && TestRecipeCRUDOperation(apiVersion)
+	}
+
+	// Reset the IMS API version to the default value
+	common.SetIMSAPIVersion("")
+	common.Infof("Testing recipe CRUD operations using default API version")
+	passed = passed && TestRecipeCRUDOperation(common.GetIMSAPIVersion())
+	return passed
+}
+
+func TestRecipeCRUDOperation(apiVersion string) (passed bool) {
 	// Test creating a recipe
 	recipeRecord, success := TestRecipeCreate()
 	if !success {
 		return false
 	}
-	// Test updating the recipe
-	updated := TestRecipeUpdate(recipeRecord.Id)
 
-	// Test soft deleting the recipe
-	deleted := TestRecipeDelete(recipeRecord.Id)
+	if apiVersion == "v2" {
+		// Test updating the recipe
+		updated := TestRecipeUpdate(recipeRecord.Id)
 
-	// Test undeleting the recipe
-	undeleted := TestRecipeUndelete(recipeRecord.Id)
+		// Test deleting the recipe
+		deleted := TestRecipeDeleteV2(recipeRecord.Id)
 
-	// Test hard deleting the recipe
-	permDeleted := TestRecipePermanentDelete(recipeRecord.Id)
+		//Test get all recipes
+		getAll := TestGetAllRecipes()
 
-	// Test get all recipes
-	getAll := TestGetAllRecipes()
+		return updated && deleted && getAll
 
-	return updated && deleted && undeleted && permDeleted && getAll
+	} else {
+		// Test updating the recipe
+		updated := TestRecipeUpdate(recipeRecord.Id)
+
+		// Test soft deleting the recipe
+		deleted := TestRecipeDelete(recipeRecord.Id)
+
+		// Test undeleting the recipe
+		undeleted := TestRecipeUndelete(recipeRecord.Id)
+
+		// Test hard deleting the recipe
+		permDeleted := TestRecipePermanentDelete(recipeRecord.Id)
+
+		// Test get all recipes
+		getAll := TestGetAllRecipes()
+
+		return updated && deleted && undeleted && permDeleted && getAll
+	}
 }
 
 func TestRecipePermanentDelete(recipeId string) (passed bool) {
@@ -174,13 +204,27 @@ func TestRecipeUpdate(recipeId string) (passed bool) {
 }
 
 func TestRecipeDelete(recipeId string) (passed bool) {
+	// Get the recipe record before deleting it
+	existingRecipeRecord, success := GetIMSRecipeRecordAPI(recipeId, http.StatusOK)
+	if !success {
+		common.Errorf("Recipe %s was not found", recipeId)
+		return false
+	}
+
 	if success := DeleteIMSRecipeRecordAPI(recipeId); !success {
 		return false
 	}
 
 	// Verify the recipe is deleted
-	if _, success := GetDeletedIMSRecipeRecordAPI(recipeId, http.StatusOK); !success {
+	recipeRecord, success := GetDeletedIMSRecipeRecordAPI(recipeId, http.StatusOK)
+	if !success {
 		common.Errorf("Recipe %s was not deleted", recipeId)
+		return false
+	}
+
+	// Verify the recipe record is the same as the one before deleting it
+	if !VerifyIMSRecipeRecord(recipeRecord, existingRecipeRecord) {
+		common.Errorf("Recipe %s details do not match after soft delete", recipeId)
 		return false
 	}
 
@@ -217,15 +261,29 @@ func TestRecipeDelete(recipeId string) (passed bool) {
 }
 
 func TestRecipeUndelete(recipeId string) (passed bool) {
+	// Get the recipe record before restoring it
+	existingRecipeRecord, success := GetDeletedIMSRecipeRecordAPI(recipeId, http.StatusOK)
+	if !success {
+		common.Errorf("Recipe %s was not found", recipeId)
+		return false
+	}
+
 	if success := UndeleteIMSRecipeRecordAPI(recipeId); !success {
 		return false
 	}
 
-	// Verify the recipe is undeleted
-	if _, success := GetIMSRecipeRecordAPI(recipeId, http.StatusOK); !success {
+	// Verify the recipe is
+	recipeRecord, success := GetIMSRecipeRecordAPI(recipeId, http.StatusOK)
+	if !success {
 		common.Errorf("Recipe %s was not restored", recipeId)
 		return false
 	}
+
+	if !VerifyIMSRecipeRecord(recipeRecord, existingRecipeRecord) {
+		common.Errorf("Recipe %s details do not match after restore", recipeId)
+		return false
+	}
+
 	common.Infof("Recipe %s was restored", recipeId)
 	return true
 }
@@ -235,5 +293,31 @@ func TestGetAllRecipes() (passed bool) {
 		return false
 	}
 	common.Infof("All recipes were retrieved")
+	return true
+}
+
+func TestRecipeDeleteV2(recipeId string) (passed bool) {
+	if success := DeleteIMSRecipeRecordAPI(recipeId); !success {
+		return false
+	}
+
+	// Verify the recipe is not in the list of recipes
+	if _, success := GetIMSRecipeRecordAPI(recipeId, http.StatusNotFound); !success {
+		common.Errorf("Recipe %s was not deleted", recipeId)
+		return false
+	}
+
+	// Verify the recipe is not in the list of all recipes
+	recipeRecords, success := GetIMSRecipeRecordsAPI()
+	if !success {
+		return false
+	}
+
+	if RecipeRecordExists(recipeId, recipeRecords) {
+		common.Errorf("Recipe %s was not deleted", recipeId)
+		return false
+	}
+
+	common.Infof("Recipe %s was deleted", recipeId)
 	return true
 }

--- a/cmsdev/internal/test/ims/verify_ims_recipes_cli.go
+++ b/cmsdev/internal/test/ims/verify_ims_recipes_cli.go
@@ -33,6 +33,7 @@ import (
  */
 
 func TestRecipeCRUDOperationUsingCLI() (passed bool) {
+	common.PrintLog("Testing recipe CRUD operations using CLI")
 	// Test creating a recipe
 	recipeRecord, success := TestCLIRecipeCreate()
 	if !success {


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
CASMCMS-9379: TESTS: IMS: cmsdev: Test v2 API and default version API
Tests are not performed for all supported versions and default API endpoints.

CASMCMS-9384: cmsdev should warn if docs-csm RPM is not installed


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

Tested on mug.

Here is log warning if an rpm is not installed

```
time="2025-04-29T18:04:25.17435543Z" level=info msg="cmsdev starting" args= run=042gg service= src="cmsdev/internal/lib/common/printlog.go:399" version=1.30.0
time="2025-04-29T18:04:25.195605663Z" level=debug msg="craycli version: craycli-0.83.4-1.x86_64" args= run=042gg service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.30.0
time="2025-04-29T18:04:25.217110275Z" level=warning msg="Package docs-csm not installed" args= run=042gg service= src="cmsdev/internal/lib/common/common.go:203" version=1.30.0
time="2025-04-29T18:04:25.217240276Z" level=debug msg="docs-csm version: " args= run=042gg service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.30.0
time="2025-04-29T18:04:25.24676404Z" level=debug msg="csm-testing version: csm-testing-1.18.7~7~g5212858-1.noarch" args= run=042gg service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.30.0
time="2025-04-29T18:04:25.268110676Z" level=debug msg="goss-servers version: goss-servers-1.18.7~7~g5212858-1.noarch" args= run=042gg service= src="cmsdev/internal/lib/common/printlog.go:401" version=1.30.0
time="2025-04-29T18:04:25.26823966Z" level=debug msg="ARTIFACTS environment variable not set. Defaulting to '/opt/cray/tests/install/logs/cmsdev/artifacts-2025-04-29T18:04:25.268204007Z'" args= run=042gg service= src="cmsdev/internal/lib/common/common.go:597" version=1.30.0
```

IMS test log is attached
[IMS_Test_Log_04_29_2025.txt](https://github.com/user-attachments/files/19965424/IMS_Test_Log_04_29_2025.txt)

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

