### PR TITLE
CASMCMS-9348: BOS sessiontemplates, sessions CRUD API cmsdev tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9348: cmsdev BOS Add create/modify/delete tests
+   * API tests for sessiontemplates and sessions
+
 ## [1.30.0] - 2025-04-29
 
 ### Added

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -47,6 +47,7 @@ const BASEHOST = "api-gw-service-nmn.local"
 const BASEURL = "https://" + BASEHOST
 const LOCALHOST = "http://localhost:5000"
 const NAMESPACE string = "services"
+const CSMPRODCATALOGCMNAME string = "cray-product-catalog"
 
 // List of API versions supported by the IMS service
 var IMSAPIVERSIONS = []string{
@@ -334,6 +335,7 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 			"GET": newMethodEndpoint("", "Retrieve CFS configurations", []int{200, 400}),
 		},
 		Url:     "/apis/cfs/v2/configurations",
+		Uri:     "/configurations",
 		Version: "v2",
 	}
 	endpoints["cfs"]["options"] = &Endpoint{
@@ -425,6 +427,47 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 		Version: "v2",
 	}
 
+	endpoints["bos"] = make(map[string]*Endpoint)
+
+	endpoints["bos"]["sessiontemplates"] = &Endpoint{
+		Methods: map[string]*endpointMethod{
+			"GET":    newMethodEndpoint("", "Retrieve all session templates", []int{200, 404}),
+			"POST":   newMethodEndpoint("", "Create a session template", []int{201, 400, 409}),
+			"PATCH":  newMethodEndpoint("", "Update a session template", []int{200, 400, 404, 409}),
+			"DELETE": newMethodEndpoint("", "Delete a session template", []int{204, 400, 404, 409}),
+		},
+		Url:     "/apis/bos",
+		Uri:     "/sessiontemplates",
+		Version: "v2",
+	}
+	endpoints["bos"]["sessions"] = &Endpoint{
+		Methods: map[string]*endpointMethod{
+			"GET":    newMethodEndpoint("", "Retrieve all sessions", []int{200, 404}),
+			"POST":   newMethodEndpoint("", "Create a session", []int{201, 400, 409}),
+			"DELETE": newMethodEndpoint("", "Delete a session", []int{204, 400, 404}),
+		},
+		Url:     "/apis/bos",
+		Uri:     "/sessions",
+		Version: "v2",
+	}
+	endpoints["bos"]["applystaged"] = &Endpoint{
+		Methods: map[string]*endpointMethod{
+			"POST": newMethodEndpoint("", "Apply staged changes", []int{200, 400}),
+		},
+		Url:     "/apis/bos",
+		Uri:     "/applystaged",
+		Version: "v2",
+	}
+
+	endpoints["bos"]["sessiontemplatesvalid"] = &Endpoint{
+		Methods: map[string]*endpointMethod{
+			"GET": newMethodEndpoint("", "Validate session template", []int{200, 400, 404}),
+		},
+		Url:     "/apis/bos",
+		Uri:     "/sessiontemplatesvalid",
+		Version: "v2",
+	}
+
 	return endpoints
 }
 
@@ -493,6 +536,11 @@ func doRest(method, url string, params Params, client *resty.Client) (*resty.Res
 		resp, err = client.R().
 			SetBody(params.JsonStrArray).
 			Patch(url)
+	case "PUT":
+		// payload passed as string
+		resp, err = client.R().
+			SetBody(params.JsonStr).
+			Put(url)
 	case "DELETE":
 		resp, err = client.R().Delete(url)
 	}

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -335,7 +335,6 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 			"GET": newMethodEndpoint("", "Retrieve CFS configurations", []int{200, 400}),
 		},
 		Url:     "/apis/cfs/v2/configurations",
-		Uri:     "/configurations",
 		Version: "v2",
 	}
 	endpoints["cfs"]["options"] = &Endpoint{

--- a/cmsdev/internal/lib/common/helpers.go
+++ b/cmsdev/internal/lib/common/helpers.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -27,10 +27,11 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"os"
 	"reflect"
 	"regexp"
+
+	"gopkg.in/yaml.v2"
 )
 
 func DecodeJSONIntoStringMap(mapJsonBytes []byte) (map[string]interface{}, error) {

--- a/cmsdev/internal/lib/k8s/k8s.go
+++ b/cmsdev/internal/lib/k8s/k8s.go
@@ -1,7 +1,7 @@
 //
 //  MIT License
 //
-//  (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+//  (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a
 //  copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	resty "gopkg.in/resty.v1"
 	"io"
 	"net/http"
 	"os"
@@ -39,8 +38,10 @@ import (
 	"regexp"
 	"strings"
 
+	resty "gopkg.in/resty.v1"
+
 	coreV1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"

--- a/cmsdev/internal/test/bos/bos_defs.go
+++ b/cmsdev/internal/test/bos/bos_defs.go
@@ -1,0 +1,97 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+package bos
+
+import "stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+
+/*
+ * bos_defs.go
+ *
+ * BOS commons file
+ *
+ */
+
+type CsmProductCatalogData struct {
+	Configuration CsmProductCatalogConfiguration `json:"configuration"`
+	Images        map[string]interface{}         `json:"images"`
+	Recipes       map[string]interface{}         `json:"recipes"`
+}
+
+type CsmProductCatalogConfiguration struct {
+	Clone_url     string `json:"clone_url"`
+	Commit        string `json:"commit"`
+	Import_branch string `json:"import_branch"`
+	Import_Date   string `json:"import_date"`
+	Ssh_url       string `json:"ssh_url"`
+}
+
+type ImageLink struct {
+	S3_Etag string `json:"etag"`
+	S3_Path string `json:"path"`
+	Type    string `json:"type"`
+}
+
+type ImsImage struct {
+	ImageID string    `json:"id"`
+	Arch    string    `json:"arch"`
+	Name    string    `json:"name"`
+	Link    ImageLink `json:"link"`
+}
+
+type BootSet struct {
+	Arch              string   `json:"arch"`
+	Etag              string   `json:"etag"`
+	Kernel_parameters string   `json:"kernel_parameters"`
+	Node_roles_groups []string `json:"node_roles_groups"`
+	Path              string   `json:"path"`
+	Type              string   `json:"type"`
+}
+
+type BOSTemplateBootSet struct {
+	Compute BootSet `json:"compute"`
+}
+
+type BOSCfs struct {
+	Configuration string `json:"configuration"`
+}
+
+type BOSSessionTemplate struct {
+	Enable_cfs bool               `json:"enable_cfs"`
+	Name       string             `json:"name"`
+	Tenant     string             `json:"tenant"`
+	Boot_sets  BOSTemplateBootSet `json:"boot_sets"`
+	Cfs        BOSCfs             `json:"cfs"`
+}
+
+type BOSSession struct {
+	Components       string `json:"components"`
+	Include_disabled bool   `json:"include_disabled"`
+	Limit            string `json:"limit"`
+	Name             string `json:"name"`
+	Operation        string `json:"operation"`
+	Stage            bool   `json:"stage"`
+	Template_name    string `json:"template_name"`
+	Tenant           string `json:"tenant"`
+}
+
+// CMS service endpoints
+var endpoints map[string]map[string]*common.Endpoint = common.GetEndpoints()

--- a/cmsdev/internal/test/bos/bos_session_tests.go
+++ b/cmsdev/internal/test/bos/bos_session_tests.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,8 +29,9 @@ package bos
  */
 
 import (
-	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"strings"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 )
 
 // The sessionsV2TestsURI and sessionsV2TestsCLICommand functions
@@ -47,6 +48,10 @@ func sessionsTestsAPI(params *common.Params, tenantList []string) (passed bool) 
 
 	// v2 sessions
 	if !sessionsV2TestsURI(params, tenantList) {
+		passed = false
+	}
+
+	if !TestBOSSessionsCRUDOperations() {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_sessions_api_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessions_api_tests.go
@@ -1,0 +1,160 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * bos_sessions_api_tests.go
+ *
+ * BOS sessions API tests.
+ *
+ */
+package bos
+
+import (
+	"fmt"
+	"net/http"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+func TestBOSSessionsCRUDOperations() (passed bool) {
+	passed = true
+	var testRan bool
+	// Range over archMap to create session templates with different architectures
+	for arch := range archMap {
+		imageId, err := GetLatestImageIdFromCsmProductCatalog(arch)
+		if err != nil {
+			common.Infof("Unable to get latest image id for architecture %s", archMap[arch])
+			common.Warnf("Skipping BOS session tests for architecture %s", archMap[arch])
+			continue
+		}
+		testRan = true
+		common.PrintLog(fmt.Sprintf("Running BOS session tests for arch %s", archMap[arch]))
+		// Ruuning test suite for both staged and non-staged sessions
+		for _, staged := range []bool{true, false} {
+			sessionRecord, success := TestBOSSessionsCreate(staged, arch, imageId)
+			if !success {
+				common.Errorf("BOS Session creation failed for imageId %s and arch %s", imageId, archMap[arch])
+				common.Warnf("Skipping rest of the BOS session tests for imageId %s and architecture %s", imageId, archMap[arch])
+				passed = false
+				continue
+			}
+
+			passed = TestBOSSessionsDelete(sessionRecord.Name) &&
+				TestBOSSessionsGetAll() && passed
+		}
+
+	}
+
+	if !testRan {
+		common.Infof("No image found for supported architecture")
+		common.Warnf("Skipping BOS session tests")
+		// No image found for supported architecture, skip the tests
+		// return true to indicate that the tests were skipped successfully
+		return true
+	}
+
+	return passed
+}
+
+func TestBOSSessionsCreate(staged bool, arch string, imageId string) (sessionRecord BOSSession, passed bool) {
+	sessionName := "BOS_Session_" + string(common.GetRandomString(10))
+	common.PrintLog(fmt.Sprintf("Creating BOS session %s with staged=%t", sessionName, staged))
+
+	// Create session payload
+	sessionPayload, success := CreateBOSSessionPayload(sessionName, staged, "reboot", arch, imageId)
+	if !success {
+		return BOSSession{}, false
+	}
+
+	common.Debugf("Create BOS session payload: %s", sessionPayload)
+	// Create staged session
+	sessionRecord, success = CreateBOSSessionAPI(sessionPayload)
+	if !success {
+		return BOSSession{}, false
+	}
+
+	// Verify the created session
+	if !VerifyBOSSession(sessionRecord, sessionPayload) {
+		common.Errorf("Verify failed for BOS session '%s'", sessionRecord.Name)
+		return BOSSession{}, false
+	}
+
+	// Get the staged session
+	_, success = GetBOSSessionAPI(sessionRecord.Name, http.StatusOK)
+	if !success {
+		common.Errorf("Failed to get BOS session '%s'", sessionRecord.Name)
+		return BOSSession{}, false
+	}
+
+	// Check if staged session is in the list of all sessions
+	sessionList, success := GetAllBOSSessionsAPI()
+	if !success {
+		return BOSSession{}, false
+	}
+
+	if !BOSSessionExists(sessionRecord.Name, sessionList) {
+		common.Errorf("BOS session '%s' not found in the list of all sessions", sessionRecord.Name)
+		return BOSSession{}, false
+	}
+	common.Infof("BOS session %s created successfully", sessionRecord.Name)
+	return sessionRecord, true
+}
+
+func TestBOSSessionsDelete(sessionName string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Deleting BOS session '%s'", sessionName))
+	// Delete staged session
+	if !DeleteBOSSessionAPI(sessionName) {
+		return false
+	}
+
+	// Check if staged session is deleted
+	_, success := GetBOSSessionAPI(sessionName, http.StatusNotFound)
+	if !success {
+		common.Errorf("BOS session '%s' still exists", sessionName)
+		return false
+	}
+
+	// Check if staged session is deleted from the list of all sessions
+	sessionList, success := GetAllBOSSessionsAPI()
+	if !success {
+		return false
+	}
+
+	if BOSSessionExists(sessionName, sessionList) {
+		common.Errorf("BOS session '%s' not deleted, found in the list of all sessions", sessionName)
+		return false
+	}
+
+	common.Infof("Deleted BOS session '%s' successfully", sessionName)
+	return true
+}
+
+func TestBOSSessionsGetAll() (passed bool) {
+	// Get all staged sessions
+	common.PrintLog("Getting all staged sessions")
+	sessionList, success := GetAllBOSSessionsAPI()
+	if !success {
+		return false
+	}
+	common.Infof("Found %d staged sessions", len(sessionList))
+	return true
+}

--- a/cmsdev/internal/test/bos/bos_sessiontemplate_api_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate_api_tests.go
@@ -1,0 +1,214 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * bos_sessiontemplate_api_tests.go
+ *
+ * BOS sessiontemplate API tests
+ *
+ */
+package bos
+
+import (
+	"fmt"
+	"net/http"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+func TestSessionTemplatesCRUDOperations() (passed bool) {
+	passed = true
+	var testRan bool
+	// Range over archMap to create session templates with different architectures
+	for arch := range archMap {
+		imageId, err := GetLatestImageIdFromCsmProductCatalog(arch)
+		if err != nil {
+			common.Infof("Unable to get latest image id for architecture %s", archMap[arch])
+			common.Warnf("Skipping BOS session template tests for architecture %s", archMap[arch])
+			continue
+		}
+		testRan = true
+		common.PrintLog(fmt.Sprintf("Running BOS session template tests for arch %s", archMap[arch]))
+		sessionTemplateRecord, ok := TestSessionTemplatesCreate(arch, imageId)
+		if !ok {
+			common.Errorf("Session template creation failed for imageId %s and arch %s", imageId, archMap[arch])
+			common.Warnf("Skipping rest of the BOS session template tests for imageId %s and architecture %s", imageId, archMap[arch])
+			passed = false
+			continue
+		}
+
+		passed = TestSessionTemplatesUpdate(sessionTemplateRecord.Name, imageId) &&
+			TestSessionTemplatesDelete(sessionTemplateRecord.Name) &&
+			TestSessionTemplatesGetAll() && passed
+	}
+
+	if !testRan {
+		common.Infof("No image found for supported architecture")
+		common.Warnf("Skipping BOS session template tests")
+		// No image found for supported architecture, skip the tests
+		// return true to indicate that the tests were skipped successfully
+		return true
+	}
+
+	return passed
+}
+
+func TestSessionTemplatesCreate(imageArch string, imageId string) (sessionTemplateRecord BOSSessionTemplate, passed bool) {
+	templateName := "BOS_SessionTemplate_" + string(common.GetRandomString(10))
+	common.PrintLog(fmt.Sprintf("Creating BOS session template %s with image ID %s and  arch %s", templateName, imageId, imageArch))
+
+	cfgName := "CFS_Configuration_" + string(common.GetRandomString(10))
+
+	// create sessiontemplates payload
+	payload, success := GetCreateBOSSessionTemplatePayload(cfgName, false, imageArch, imageId)
+	if !success {
+		return BOSSessionTemplate{}, false
+	}
+	common.Debugf("BOS Session template create payload: %s", payload)
+	// Create session template
+	sessionTemplateRecord, success = CreateUpdateBOSSessiontemplatesAPI(payload, templateName, "PUT")
+	if !success {
+		return BOSSessionTemplate{}, false
+	}
+
+	// Verify sessiontemplate
+	if !VerifyBOSSessionTemplate(sessionTemplateRecord, payload, templateName) {
+		common.Errorf("Session template %s verification failed", sessionTemplateRecord.Name)
+		return BOSSessionTemplate{}, false
+	}
+
+	// Get the created session template
+	_, success = GetBOSSessionTemplatesAPI(sessionTemplateRecord.Name, http.StatusOK)
+	if !success {
+		common.Errorf("Unable to get BOS session template %s", sessionTemplateRecord.Name)
+		return BOSSessionTemplate{}, false
+	}
+
+	// verify session template in list of session templates
+	sessionTemplateRecords, success := GetAllBOSSessionTemplatesAPI()
+	if !success {
+		common.Errorf("Unable to get all session templates")
+		return BOSSessionTemplate{}, false
+	}
+
+	if !BOSSessionTemplateExists(sessionTemplateRecord.Name, sessionTemplateRecords) {
+		common.Errorf("BOS session template %s not found in list of session templates", sessionTemplateRecord.Name)
+		return BOSSessionTemplate{}, false
+	}
+
+	// Validate session template
+	if !ValidateBOSSessionTemplateAPI(sessionTemplateRecord.Name) {
+		return BOSSessionTemplate{}, false
+	}
+
+	common.Infof("Session template %s created successfully", sessionTemplateRecord.Name)
+	return sessionTemplateRecord, true
+
+}
+
+func TestSessionTemplatesUpdate(templateName string, imageId string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Updating session template %s", templateName))
+	cfgName := "CFS_Configuration_" + string(common.GetRandomString(10))
+
+	sessionTemplate, success := GetBOSSessionTemplatesAPI(templateName, http.StatusOK)
+	if !success {
+		common.Errorf("Unable to get session template %s", templateName)
+		return false
+	}
+
+	payload, success := GetCreateBOSSessionTemplatePayload(cfgName, true, sessionTemplate.Boot_sets.Compute.Arch, imageId)
+	if !success {
+		return false
+	}
+	common.Debugf("Session template update payload: %s", payload)
+	sessionTemplateRecord, success := CreateUpdateBOSSessiontemplatesAPI(payload, templateName, "PATCH")
+	if !success {
+		common.Errorf("Session template %s update failed", templateName)
+		return false
+	}
+
+	// Verify sessiontemplate
+	if !VerifyBOSSessionTemplate(sessionTemplateRecord, payload, templateName) {
+		common.Errorf("Session template %s verification failed", sessionTemplateRecord.Name)
+		return false
+	}
+
+	// Get the created session template
+	_, success = GetBOSSessionTemplatesAPI(sessionTemplateRecord.Name, http.StatusOK)
+	if !success {
+		common.Errorf("Unable to get BOS session template %s", sessionTemplateRecord.Name)
+		return false
+	}
+
+	// Validate session template
+	if !ValidateBOSSessionTemplateAPI(sessionTemplateRecord.Name) {
+		return false
+	}
+
+	common.Infof("Session template %s updated successfully", templateName)
+	return true
+
+}
+
+func TestSessionTemplatesDelete(templateName string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Deleting session template %s", templateName))
+	// Delete session template
+	if !DeleteBOSSessionTemplatesAPI(templateName) {
+		common.Errorf("Unable to delete sessiontemplate %s", templateName)
+		return false
+	}
+
+	// Get the deleted session template
+	_, success := GetBOSSessionTemplatesAPI(templateName, http.StatusNotFound)
+	if !success {
+		common.Errorf("BOS sessiontemplate %s was not deleted", templateName)
+		return false
+	}
+
+	// verify session template in list of session templates
+	sessionTemplateRecords, success := GetAllBOSSessionTemplatesAPI()
+	if !success {
+		common.Errorf("Unable to get all session templates")
+		return false
+	}
+
+	if BOSSessionTemplateExists(templateName, sessionTemplateRecords) {
+		common.Errorf("BOS session template %s not deleted, found in list of session templates", templateName)
+		return false
+	}
+
+	common.Infof("Deleted sessiontemplate %s successfully", templateName)
+	return true
+}
+
+func TestSessionTemplatesGetAll() (passed bool) {
+	common.PrintLog("Getting all session templates")
+	// Get all session templates
+	sessionTemplateRecords, success := GetAllBOSSessionTemplatesAPI()
+	if !success {
+		common.Errorf("Unable to get all session templates")
+		return false
+	}
+
+	common.Infof("Found %d BOS sessiontemplates", len(sessionTemplateRecords))
+	return true
+}

--- a/cmsdev/internal/test/bos/bos_sessiontemplate_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate_tests.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,8 +29,9 @@ package bos
  */
 
 import (
-	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"strings"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 )
 
 // The sessionTemplatesTestsURI and sessionTemplatesTestsCLICommand functions define the API and CLI versions of the BOS session template subtests.
@@ -57,6 +58,10 @@ func sessionTemplatesTestsAPI(params *common.Params, tenantList []string) (passe
 
 	// v2
 	if !v2SessionTemplatesTestsURI(params, tenantList) {
+		passed = false
+	}
+
+	if !TestSessionTemplatesCRUDOperations() {
 		passed = false
 	}
 

--- a/cmsdev/internal/test/bos/bos_sessiontemplates_api.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplates_api.go
@@ -1,0 +1,398 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+/*
+ * bos_sessiontemplates_api.go
+ *
+ * BOS sessiontemplates API.
+ *
+ */
+package bos
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
+
+/*
+ * bos_helper.go
+ *
+ * BOS test helper file
+ *
+ */
+
+var DEFAULT_PLAYBOOK = "compute_nodes.yml"
+var archMap = map[string]string{
+	"X86": "x86_64",
+	"ARM": "aarch64",
+}
+
+func GetCsmProductCatalogData() (data map[string]interface{}, err error) {
+	resp, err := k8s.GetConfigMapDataField(common.NAMESPACE, common.CSMPRODCATALOGCMNAME, "csm")
+	if err != nil {
+		return nil, err
+	}
+
+	//convert YAML
+	respMap, err := common.DecodeYAMLIntoStringMap(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return respMap, nil
+}
+
+func GetCSMLatestVersion(prodCatlogData map[string]interface{}) (version string, err error) {
+	// Sort the keys in the JSON object to ensure consistent ordering
+	keys := make([]string, 0, len(prodCatlogData))
+	for key := range prodCatlogData {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		return "", fmt.Errorf("no keys found in the configuration map")
+	}
+	//Get the last key from the sorted keys where version has both configuration and images as keys
+	latestCSMVersion := ""
+	for i := len(keys) - 1; i >= 0; i-- {
+		key := keys[i]
+		if _, ok := prodCatlogData[key].(map[interface{}]interface{})["configuration"]; ok {
+			if _, ok := prodCatlogData[key].(map[interface{}]interface{})["images"]; ok {
+				latestCSMVersion = key
+				break
+			}
+		}
+	}
+
+	common.Infof("Latest CSM version: %s", latestCSMVersion)
+	return latestCSMVersion, nil
+}
+
+func GetLatestImageIdFromCsmProductCatalog(arch string) (string, error) {
+	csmProductCatalogData, err := GetCsmProductCatalogData()
+	if err != nil {
+		return "", err
+	}
+
+	// Get the latest CSM version data
+	csmVersion, err := GetCSMLatestVersion(csmProductCatalogData)
+	if err != nil {
+		return "", err
+	}
+
+	lastestCSMDataRaw := csmProductCatalogData[csmVersion]
+
+	common.Debugf("Latest CSM data: %v", lastestCSMDataRaw)
+
+	latestCSMData := lastestCSMDataRaw.(map[interface{}]interface{})
+
+	// Access the "images" field from the unmarshaled map
+	csmImages, ok := latestCSMData["images"].(map[interface{}]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed to retrieve 'images' field from latest CSM data")
+	}
+	common.Infof("CSM images: %v", csmImages)
+	for key := range csmImages {
+		// Return the first key found
+		if strings.Contains(key.(string), archMap[arch]) {
+			common.Debugf("Found image ID for architecture %s: %s", archMap[arch], csmImages[key])
+			return csmImages[key].(map[interface{}]interface{})["id"].(string), nil
+		}
+	}
+	return "", fmt.Errorf("no image found in the latest CSM data")
+}
+
+func GetImageRecord(imageID string) (imagerecord ImsImage, ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return ImsImage{}, false
+	}
+
+	url := common.BASEURL + endpoints["ims"]["images"].Url + endpoints["ims"]["images"].Uri + "/" + imageID
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return ImsImage{}, false
+	}
+
+	// Unmarshal the response into the ImsImage struct
+	if err := json.Unmarshal(resp.Body(), &imagerecord); err != nil {
+		common.Error(err)
+		return ImsImage{}, false
+	}
+
+	ok = true
+	return
+}
+
+func GetCreateBOSSessionTemplatePayload(cfsConfigName string, enableCFS bool, arch string, imageId string) (bosSessionTemplatePayload string, ok bool) {
+	// Get the latest image ID from the CSM product catalog
+	// and the image record from the IMS API based on architecture
+	// imageId, err := GetLatestImageIdFromCsmProductCatalog(arch)
+	// if err != nil {
+	// 	common.Error(err)
+	// 	return "", false
+	// }
+	// common.Infof("Using image ID %s with arch: %s", imageId, arch)
+	imageRecord, ok := GetImageRecord(imageId)
+	if !ok {
+		return "", false
+	}
+	kernelParameters :=
+		"console=ttyS0,115200 bad_page=panic crashkernel=512M hugepagelist=2m-2g " +
+			"intel_iommu=off intel_pstate=disable iommu.passthrough=on " +
+			"modprobe.blacklist=amdgpu numa_interleave_omit=headless oops=panic pageblock_order=14 " +
+			"rd.neednet=1 rd.retry=10 rd.shell split_lock_detect=off " +
+			"systemd.unified_cgroup_hierarchy=1 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} " +
+			fmt.Sprintf("root=live:s3://boot-images/%s/rootfs ", imageRecord.Name) +
+			fmt.Sprintf("nmd_data=url=s3://boot-images/%s/rootfs,etag=%s", imageRecord.Name, imageRecord.Link.S3_Etag)
+
+	computeSet := map[string]interface{}{
+		"etag":              imageRecord.Link.S3_Etag,
+		"kernel_parameters": kernelParameters,
+		"node_roles_groups": []string{"Compute"},
+		"path":              imageRecord.Link.S3_Path,
+		"type":              "s3",
+		"arch":              arch,
+	}
+
+	cfsConfig := map[string]string{
+		"configuration": cfsConfigName,
+	}
+
+	bosParams := map[string]interface{}{
+		"cfs":        cfsConfig,
+		"enable_cfs": enableCFS,
+		"boot_sets": map[string]interface{}{
+			"compute": computeSet,
+		},
+	}
+
+	jsonPayload, err := json.Marshal(bosParams)
+	if err != nil {
+		common.Error(err)
+		return "", false
+	}
+
+	return string(jsonPayload), true
+}
+
+func CreateUpdateBOSSessiontemplatesAPI(bosSessionTemplatePayload string, sessionTemplateName string, method string) (bosSessionTemplate BOSSessionTemplate, ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return BOSSessionTemplate{}, false
+	}
+
+	// Create the BOS session template payload
+	if method == "PUT" {
+		// Create session template payload
+		params.JsonStr = bosSessionTemplatePayload
+	} else {
+		// Update session template payload
+		params.JsonStrArray = []byte(bosSessionTemplatePayload)
+	}
+
+	url := common.BASEURL + endpoints["bos"]["sessiontemplates"].Url +
+		"/" + endpoints["bos"]["sessiontemplates"].Version +
+		endpoints["bos"]["sessiontemplates"].Uri + "/" + sessionTemplateName
+	resp, err := test.RestfulVerifyStatus(method, url, *params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return BOSSessionTemplate{}, false
+	}
+
+	// Decode the response body into the BOSSessionTemplate struct
+	if err := json.Unmarshal(resp.Body(), &bosSessionTemplate); err != nil {
+		common.Error(err)
+		return BOSSessionTemplate{}, false
+	}
+
+	ok = true
+	return
+}
+
+func DeleteBOSSessionTemplatesAPI(sessionTemplateName string) (ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return false
+	}
+
+	url := common.BASEURL + endpoints["bos"]["sessiontemplates"].Url +
+		"/" + endpoints["bos"]["sessiontemplates"].Version +
+		endpoints["bos"]["sessiontemplates"].Uri + "/" + sessionTemplateName
+	_, err := test.RestfulVerifyStatus("DELETE", url, *params, http.StatusNoContent)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	ok = true
+	return
+}
+
+func ValidateBOSSessionTemplateAPI(templateName string) (ok bool) {
+	common.Infof("Validating BOS sessiontemplate '%s'", templateName)
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Errorf("Unable to get access token params")
+		return false
+	}
+
+	url := common.BASEURL + endpoints["bos"]["sessiontemplatesvalid"].Url +
+		"/" + endpoints["bos"]["sessiontemplatesvalid"].Version +
+		endpoints["bos"]["sessiontemplatesvalid"].Uri + "/" + templateName
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	if strings.Contains(string(resp.Body()), "Valid") {
+		common.Infof("Session template %s is valid", templateName)
+		ok = true
+	} else {
+		common.Errorf("Session template %s is not valid", templateName)
+		ok = false
+	}
+
+	return
+
+}
+
+func GetBOSSessionTemplatesAPI(templateName string, httpStatus int) (bosSessionTemplate BOSSessionTemplate, ok bool) {
+	common.Infof("Getting BOS sessiontemplate '%s'", templateName)
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Errorf("Unable to get access token params")
+		return BOSSessionTemplate{}, false
+	}
+
+	url := common.BASEURL + endpoints["bos"]["sessiontemplates"].Url +
+		"/" + endpoints["bos"]["sessiontemplates"].Version +
+		endpoints["bos"]["sessiontemplates"].Uri + "/" + templateName
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, httpStatus)
+	if err != nil {
+		common.Error(err)
+		return BOSSessionTemplate{}, false
+	}
+
+	// Decode the response body into the BOSSessionTemplate struct
+	if err := json.Unmarshal(resp.Body(), &bosSessionTemplate); err != nil {
+		common.Error(err)
+		return BOSSessionTemplate{}, false
+	}
+
+	ok = true
+	return
+}
+
+func GetAllBOSSessionTemplatesAPI() (bosSessionTemplates []BOSSessionTemplate, ok bool) {
+	common.Infof("Getting all BOS sessiontemplates")
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Errorf("Unable to get access token params")
+		return []BOSSessionTemplate{}, false
+	}
+
+	url := common.BASEURL + endpoints["bos"]["sessiontemplates"].Url +
+		"/" + endpoints["bos"]["sessiontemplates"].Version +
+		endpoints["bos"]["sessiontemplates"].Uri
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+	if err != nil {
+		common.Error(err)
+		return []BOSSessionTemplate{}, false
+	}
+
+	// Decode the response body into the BOSSessionTemplate struct
+	if err := json.Unmarshal(resp.Body(), &bosSessionTemplates); err != nil {
+		common.Error(err)
+		return []BOSSessionTemplate{}, false
+	}
+
+	ok = true
+	return
+}
+
+func BOSSessionTemplateExists(sessionTemplateName string, templateList []BOSSessionTemplate) (ok bool) {
+	for _, template := range templateList {
+		if template.Name == sessionTemplateName {
+			return true
+		}
+	}
+	common.Infof("Sessiontemplate %s was not found in the list of sessiontemplates", sessionTemplateName)
+	return false
+}
+
+func VerifyBOSSessionTemplate(sessionTemplate BOSSessionTemplate, sessionTemplatePayload string, templateName string) (ok bool) {
+	// Unmarshal the session template payload into a BOSSessionTemplate struct
+	var expectedSessionTemplate BOSSessionTemplate
+	if err := json.Unmarshal([]byte(sessionTemplatePayload), &expectedSessionTemplate); err != nil {
+		common.Errorf("Error unmarshaling session template payload: %v", err)
+		return false
+	}
+
+	if sessionTemplate.Name != templateName {
+		common.Errorf("Session template name does not match. Expected: %s, Got: %s", templateName, sessionTemplate.Name)
+		return false
+	}
+
+	if sessionTemplate.Enable_cfs != expectedSessionTemplate.Enable_cfs {
+		common.Errorf("Enable CFS does not match. Expected: %v, Got: %v", expectedSessionTemplate.Enable_cfs, sessionTemplate.Enable_cfs)
+		return false
+	}
+
+	if sessionTemplate.Boot_sets.Compute.Kernel_parameters != expectedSessionTemplate.Boot_sets.Compute.Kernel_parameters {
+		common.Errorf("Kernel parameters do not match. Expected: %s, Got: %s", expectedSessionTemplate.Boot_sets.Compute.Kernel_parameters, sessionTemplate.Boot_sets.Compute.Kernel_parameters)
+		return false
+	}
+
+	if sessionTemplate.Boot_sets.Compute.Etag != expectedSessionTemplate.Boot_sets.Compute.Etag {
+		common.Errorf("Etag does not match. Expected: %s, Got: %s", expectedSessionTemplate.Boot_sets.Compute.Etag, sessionTemplate.Boot_sets.Compute.Etag)
+		return false
+	}
+
+	if sessionTemplate.Boot_sets.Compute.Path != expectedSessionTemplate.Boot_sets.Compute.Path {
+		common.Errorf("Path does not match. Expected: %s, Got: %s", expectedSessionTemplate.Boot_sets.Compute.Path, sessionTemplate.Boot_sets.Compute.Path)
+		return false
+	}
+
+	if sessionTemplate.Boot_sets.Compute.Type != expectedSessionTemplate.Boot_sets.Compute.Type {
+		common.Errorf("Type does not match. Expected: %s, Got: %s", expectedSessionTemplate.Boot_sets.Compute.Type, sessionTemplate.Boot_sets.Compute.Type)
+		return false
+	}
+
+	if sessionTemplate.Boot_sets.Compute.Node_roles_groups[0] != expectedSessionTemplate.Boot_sets.Compute.Node_roles_groups[0] {
+		common.Errorf("Node roles groups do not match. Expected: %s, Got: %s", expectedSessionTemplate.Boot_sets.Compute.Node_roles_groups[0], sessionTemplate.Boot_sets.Compute.Node_roles_groups[0])
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9348: BOS sessiontemplates, sessions CRUD API cmsdev tests
Tests added in cmsdev testsuite for BOS sessiontemplates and sessions.

- Sessiontemplates: It requires cfs configurations name, It also requires `boot_sets` related information which is dependent on 
images. The test is intended for BOS so using a dummy cfs configuration name since there is no validation for cfs configuration name if it exists or not.

* Test is designed to created session temapate for x86 and ARM architectures.
* Test suite includes create, update, delete, get by session tempate name and get all session templates.
* Other CRUD tests are skipped if create session template failes.
* Test suite is skipped if x86 and ARM images are not present in product catalog. test is marked as passed
   and a warning is logged.
* Following validations are performed after session template creation.
   + Verify the data of session template with data supplied in the creation payload.
   + Get session template by name.
   + Get all session templates and verify the newly created session template is in the list.
   + Validate the created session template with `sessiontemplatevalid` API.

- Sessions: The test needs session template as key parameter and is validated during creating session if session template exists or not. 

* Test is designed to use session template for  x86 and ARM architectures.
* Test is designed to create staged and non staged sesisons.
* Other CRUD tests are skipped if create session failes.
* Test suite is skipped if x86 and ARM images are not present in product catalog. test is marked as passed
   and a warning is logged.
* Sesison is created with `limit` option and a dummy `xname` is specified to restrict the test to be non destructive.
* Following validations are performed after session creation.
   + Verify the data of session with data supplied in the creation payload.
   + Get session by name.
   + Get all session and verify the newly created session is in the list.



## Testing
Testing was performed on mug and test log is attached for reference.
[cmsdev_bos_test_log_05112025.txt](https://github.com/user-attachments/files/20153314/cmsdev_bos_test_log_05112025.txt)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

