### PR TITLE
CASMCMS-9409,CASMCMS-9348: BOS sessiontemplates and sessions CLI tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CASMCMS-9348: cmsdev BOS Add create/modify/delete tests
    * API tests for sessiontemplates and sessions
+   * CLI tests for sessiontemplates and sessions
+- CASMCMS-9409: IMS cli test should suppress expected failures from log
 
 ## [1.30.0] - 2025-04-29
 

--- a/cmsdev/internal/test/bos/bos_cli.go
+++ b/cmsdev/internal/test/bos/bos_cli.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -29,9 +29,10 @@ package bos
  */
 
 import (
+	"strings"
+
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
-	"strings"
 )
 
 // Wrapper function for test.RunCLICommandJSON. Prepends "bos" to a CLI command list and then runs it.

--- a/cmsdev/internal/test/bos/bos_session_tests.go
+++ b/cmsdev/internal/test/bos/bos_session_tests.go
@@ -71,6 +71,10 @@ func sessionsTestsCLI(tenantList []string) (passed bool) {
 		passed = false
 	}
 
+	if !TestSessionsCRUDOperationsUsingCLI() {
+		passed = false
+	}
+
 	return
 }
 

--- a/cmsdev/internal/test/bos/bos_sessions_api_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessions_api_tests.go
@@ -86,7 +86,7 @@ func TestBOSSessionsCreate(staged bool, arch string, imageId string) (sessionRec
 	}
 
 	common.Debugf("Create BOS session payload: %s", sessionPayload)
-	// Create staged session
+	// Create BOS session
 	sessionRecord, success = CreateBOSSessionAPI(sessionPayload)
 	if !success {
 		return BOSSession{}, false
@@ -98,14 +98,14 @@ func TestBOSSessionsCreate(staged bool, arch string, imageId string) (sessionRec
 		return BOSSession{}, false
 	}
 
-	// Get the staged session
+	// Get the BOS session
 	_, success = GetBOSSessionAPI(sessionRecord.Name, http.StatusOK)
 	if !success {
 		common.Errorf("Failed to get BOS session '%s'", sessionRecord.Name)
 		return BOSSession{}, false
 	}
 
-	// Check if staged session is in the list of all sessions
+	// Check if BOS session is in the list of all sessions
 	sessionList, success := GetAllBOSSessionsAPI()
 	if !success {
 		return BOSSession{}, false
@@ -121,19 +121,19 @@ func TestBOSSessionsCreate(staged bool, arch string, imageId string) (sessionRec
 
 func TestBOSSessionsDelete(sessionName string) (passed bool) {
 	common.PrintLog(fmt.Sprintf("Deleting BOS session '%s'", sessionName))
-	// Delete staged session
+	// Delete BOS session
 	if !DeleteBOSSessionAPI(sessionName) {
 		return false
 	}
 
-	// Check if staged session is deleted
+	// Check if BOS session is deleted
 	_, success := GetBOSSessionAPI(sessionName, http.StatusNotFound)
 	if !success {
 		common.Errorf("BOS session '%s' still exists", sessionName)
 		return false
 	}
 
-	// Check if staged session is deleted from the list of all sessions
+	// Check if BOS session is deleted from the list of all sessions
 	sessionList, success := GetAllBOSSessionsAPI()
 	if !success {
 		return false
@@ -149,12 +149,12 @@ func TestBOSSessionsDelete(sessionName string) (passed bool) {
 }
 
 func TestBOSSessionsGetAll() (passed bool) {
-	// Get all staged sessions
-	common.PrintLog("Getting all staged sessions")
+	// Get all BOS sessions
+	common.PrintLog("Getting all BOS sessions")
 	sessionList, success := GetAllBOSSessionsAPI()
 	if !success {
 		return false
 	}
-	common.Infof("Found %d staged sessions", len(sessionList))
+	common.Infof("Found %d BOS sessions", len(sessionList))
 	return true
 }

--- a/cmsdev/internal/test/bos/bos_sessions_cli.go
+++ b/cmsdev/internal/test/bos/bos_sessions_cli.go
@@ -1,0 +1,81 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * bos_sessions_cli.go
+ *
+ * BOS sessions helper function
+ *
+ */
+package bos
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+func CreateBOSSessionCLI(staged bool, sessionName, templateName, cliVersion string) (sessionRecord BOSSession, ok bool) {
+	common.Infof("Creating session template %s in BOS via CLI", sessionName)
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessions", "create", "--name", sessionName, "--stage", strconv.FormatBool(staged),
+		"--template-name", templateName, "--operation", "reboot", "--limit", "fakexname"); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionRecord); err == nil {
+			ok = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func GetBOSSessionRecordCLI(sessionName, cliVersion string) (sessionRecord BOSSession, ok bool) {
+	common.Infof("Getting session %s in BOS via CLI", sessionName)
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessions", "describe", sessionName); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionRecord); err == nil {
+			ok = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func GetBOSSessionRecordsCLI(cliVersion string) (sessionRecords []BOSSession, ok bool) {
+	common.Infof("Getting all sessions in BOS via CLI")
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessions", "list"); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionRecords); err == nil {
+			ok = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func DeleteBOSSessionCLI(sessionName, cliVersion string) (ok bool) {
+	common.Infof("Deleting session %s in BOS via CLI", sessionName)
+	return RunVersionedBOSCommand(cliVersion, "sessions", "delete", sessionName) != nil
+}

--- a/cmsdev/internal/test/bos/bos_sessions_cli_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessions_cli_tests.go
@@ -1,0 +1,200 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * bos_sessions_cli_tests.go
+ *
+ * BOS sessions CLI tests
+ *
+ */
+package bos
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
+
+func TestSessionsCRUDOperationsUsingCLI() (passed bool) {
+	passed = true
+	var testRan bool
+	// Range over archMap to create session templates with different architectures
+	for arch := range archMap {
+		imageId, err := GetLatestImageIdFromCsmProductCatalog(arch)
+		if err != nil {
+			common.Infof("Unable to get latest image id for architecture %s", archMap[arch])
+			common.Warnf("Skipping BOS session tests for architecture %s", archMap[arch])
+			continue
+		}
+		testRan = true
+		for cliVersion := range bosCliVersions {
+			common.PrintLog(fmt.Sprintf("Running BOS session CLI tests with version %s", cliVersion))
+			// Ruuning test suite for both staged and non-staged sessions
+			for _, staged := range []bool{true, false} {
+				sessionRecord, success := TestCLIBOSSessionsCreate(staged, arch, imageId, bosCliVersions[cliVersion])
+				if !success {
+					common.Errorf("BOS Session creation failed for imageId %s and arch %s", imageId, archMap[arch])
+					common.Warnf("Skipping rest of the BOS session tests for imageId %s and architecture %s", imageId, archMap[arch])
+					passed = false
+					continue
+				}
+
+				passed = TestCLIBOSSessionsDelete(sessionRecord.Name, bosCliVersions[cliVersion]) &&
+					TestCLiBOSSessionsGetAll(bosCliVersions[cliVersion]) && passed
+			}
+		}
+	}
+
+	if !testRan {
+		common.Infof("No image found for supported architecture")
+		common.Warnf("Skipping BOS session tests")
+		// No image found for supported architecture, skip the tests
+		// return true to indicate that the tests were skipped successfully
+		return true
+	}
+
+	return passed
+}
+
+func TestCLIBOSSessionsCreate(staged bool, arch, imageId, cliVersion string) (sessionRecord BOSSession, passed bool) {
+	// Create a session using the CLI
+	sessionName := "BOS_Session_" + string(common.GetRandomString(10))
+	common.PrintLog(fmt.Sprintf("Creating BOS session %s with staged=%t and arch %s", sessionName, staged, archMap[arch]))
+
+	cfgName := "CFS_Configuration_" + string(common.GetRandomString(10))
+	templateName := "BOS_SessionTemplate_" + string(common.GetRandomString(10))
+
+	// Create Bos session template payload needed for session creation
+	fileName, _, success := GetCreateBOSSessionTemplatePayloadCLI(cfgName, true, arch, imageId)
+	if !success {
+		return BOSSession{}, false
+	}
+
+	// Create BOS session template using the payload
+	sessionTemplateRecord, success := CreateBOSSessionTemplatesCLI(templateName, fileName, cfgName, cliVersion)
+	if !success {
+		common.Errorf("Session template creation failed for imageId %s and arch %s", imageId, archMap[arch])
+		return BOSSession{}, false
+	}
+
+	// remove the session template file after creation
+	if err := os.Remove(fileName); err != nil {
+		common.Errorf("Unable to remove session template file %s: %v", fileName, err)
+	}
+
+	sessionRecord, success = CreateBOSSessionCLI(staged, sessionName, sessionTemplateRecord.Name, cliVersion)
+	if !success {
+		common.Errorf("Session creation failed for imageId %s and arch %s", imageId, archMap[arch])
+		return BOSSession{}, false
+	}
+
+	// Creating expected session record for verification
+	expectedBOSSession := BOSSession{
+		Name:          sessionName,
+		Template_name: sessionTemplateRecord.Name,
+		Stage:         staged,
+		Operation:     "reboot",
+		Limit:         "fakexname",
+	}
+
+	// Marshalling the expected session record to JSON format
+	expectedBOSSessionJson, err := json.Marshal(expectedBOSSession)
+	if err != nil {
+		common.Errorf("Error marshalling expected session record: %v", err)
+		return BOSSession{}, false
+	}
+
+	// Verify the created session
+	if !VerifyBOSSession(sessionRecord, string(expectedBOSSessionJson)) {
+		common.Errorf("Verify failed for BOS session '%s'", sessionRecord.Name)
+		return BOSSession{}, false
+	}
+
+	// Get the BOS session
+	_, success = GetBOSSessionRecordCLI(sessionRecord.Name, cliVersion)
+	if !success {
+		return BOSSession{}, false
+	}
+
+	// Verify session in list of sessions
+	sessionList, success := GetBOSSessionRecordsCLI(cliVersion)
+
+	if !success {
+		return BOSSession{}, false
+	}
+
+	if !BOSSessionExists(sessionRecord.Name, sessionList) {
+		common.Errorf("BOS session '%s' not found in the list of all sessions", sessionRecord.Name)
+		return BOSSession{}, false
+	}
+	common.Infof("BOS session %s created successfully", sessionRecord.Name)
+	return sessionRecord, true
+}
+
+func TestCLIBOSSessionsDelete(sessionName, cliVersion string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Deleting BOS session '%s'", sessionName))
+	// Delete BOS session
+	if !DeleteBOSSessionCLI(sessionName, cliVersion) {
+		return false
+	}
+
+	// Set CLI execution return code to 2. Since the session is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
+	// Check if BOS session is deleted
+	_, success := GetBOSSessionRecordCLI(sessionName, cliVersion)
+	if success {
+		common.Errorf("BOS session '%s' still exists", sessionName)
+		return false
+	}
+
+	// Set CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
+
+	// Check if BOS session is deleted from the list of all sessions
+	sessionList, success := GetBOSSessionRecordsCLI(cliVersion)
+	if !success {
+		return false
+	}
+
+	if BOSSessionExists(sessionName, sessionList) {
+		common.Errorf("BOS session '%s' not deleted, found in the list of all sessions", sessionName)
+		return false
+	}
+
+	common.Infof("Deleted BOS session '%s' successfully", sessionName)
+	return true
+}
+
+func TestCLiBOSSessionsGetAll(cliVersion string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Getting all BOS sessions"))
+	// Get all BOS sessions using the CLI
+	sessionList, success := GetBOSSessionRecordsCLI(cliVersion)
+	if !success {
+		return false
+	}
+
+	common.Infof("Found %d BOS sessions", len(sessionList))
+	return true
+}

--- a/cmsdev/internal/test/bos/bos_sessiontemplate_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplate_tests.go
@@ -96,6 +96,11 @@ func sessionTemplatesTestsCLI(tenantList []string) (passed bool) {
 		passed = false
 	}
 
+	// sessiontemplates CRUD operations tests
+	if !TestSessionTemplatesCRUDOperationsUsingCLI() {
+		passed = false
+	}
+
 	return
 }
 

--- a/cmsdev/internal/test/bos/bos_sessiontemplates_cli.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplates_cli.go
@@ -1,0 +1,152 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * bos_sessiontemplate_cli.go
+ *
+ * BOS sessiontemplate CLI helper functions
+ *
+ */
+package bos
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+// BOS cli versions
+var bosCliVersions = map[string]string{
+	"default": "",
+	"v2":      "v2",
+}
+
+func RunVersionedBOSCommand(cliVersion string, cmdArgs ...string) []byte {
+	if cliVersion == "" {
+		return runBosCLI(cmdArgs...)
+
+	}
+	newArgs := append([]string{cliVersion}, cmdArgs...)
+	return runBosCLI(newArgs...)
+}
+
+func GetCreateBOSSessionTemplatePayloadCLI(cfsConfigName string, enableCFS bool, arch string, imageId string) (fileName string, payload string, ok bool) {
+	fileName = "bos_sessiontemplate_create_payload"
+	payload, success := GetCreateBOSSessionTemplatePayload(cfsConfigName, enableCFS, arch, imageId)
+	if !success {
+		return "", "", false
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		common.Errorf("Error getting current directory: %v\n", err)
+		return
+	}
+	fileName = fmt.Sprintf("%s/%s_%s.json", dir, fileName, arch)
+
+	// Write the formatted JSON payload to the file
+	err = os.WriteFile(fileName, []byte(payload), 0644)
+	if err != nil {
+		common.Errorf("Unable to write payload to file %s: %v", fileName, err)
+		return "", "", false
+	}
+
+	return fileName, payload, true
+}
+
+func UpdateBOSSessionTemplatesCLI(templateName, filename, cfgName, cliVersion string) (sessionTemplateRecord BOSSessionTemplate, passed bool) {
+	common.Infof("Updating session template %s in BOS via CLI", templateName)
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessiontemplates", "update", templateName,
+		"--file", filename); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionTemplateRecord); err == nil {
+			passed = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func CreateBOSSessionTemplatesCLI(templateName, filename, cfgName, cliVersion string) (sessionTemplateRecord BOSSessionTemplate, passed bool) {
+	common.Infof("Creating session template %s in BOS via CLI", templateName)
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessiontemplates", "create", templateName,
+		"--file", filename); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionTemplateRecord); err == nil {
+			passed = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func GetBOSSessiontemplatesCLI(templateName, cliVersion string) (sessionTemplateRecord BOSSessionTemplate, passed bool) {
+	common.Infof("Getting BOS session template %s via CLI", templateName)
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessiontemplates", "describe", templateName); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionTemplateRecord); err == nil {
+			passed = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func GetBOSSessiontemplatesListCLI(cliVersion string) (sessionTemplateRecords []BOSSessionTemplate, passed bool) {
+	common.Infof("Getting all BOS session templates via CLI")
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessiontemplates", "list"); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		if err := json.Unmarshal(cmdOut, &sessionTemplateRecords); err == nil {
+			passed = true
+		} else {
+			common.Error(err)
+		}
+	}
+	return
+}
+
+func DeleteBOSSessionTemplatesCLI(templateName, cliVersion string) (passed bool) {
+	common.Infof("Deleting session template %s in BOS via CLI", templateName)
+	return RunVersionedBOSCommand(cliVersion, "sessiontemplates", "delete", templateName) != nil
+}
+
+func ValidateBOSSessionTemplateCLI(templateName, cliVersion string) (passed bool) {
+	common.Infof("Validating BOS session template %s via CLI", templateName)
+	if cmdOut := RunVersionedBOSCommand(cliVersion, "sessiontemplatesvalid", "describe", templateName); cmdOut != nil {
+		common.Infof("Decoding JSON in command output")
+		output := string(cmdOut)
+		if strings.Contains(output, "Valid") {
+			common.Infof("Session template %s is valid", templateName)
+			passed = true
+		} else {
+			common.Errorf("Session template %s is not valid", templateName)
+			passed = false
+		}
+	}
+	return
+}

--- a/cmsdev/internal/test/bos/bos_sessiontemplates_cli.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplates_cli.go
@@ -46,7 +46,6 @@ var bosCliVersions = map[string]string{
 func RunVersionedBOSCommand(cliVersion string, cmdArgs ...string) []byte {
 	if cliVersion == "" {
 		return runBosCLI(cmdArgs...)
-
 	}
 	newArgs := append([]string{cliVersion}, cmdArgs...)
 	return runBosCLI(newArgs...)

--- a/cmsdev/internal/test/bos/bos_sessiontemplates_cli_tests.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplates_cli_tests.go
@@ -1,0 +1,245 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * bos_sessiontemplate_cli_tests.go
+ *
+ * BOS sessiontemplate CLI tests
+ *
+ */
+package bos
+
+import (
+	"fmt"
+	"os"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
+
+func TestSessionTemplatesCRUDOperationsUsingCLI() (passed bool) {
+	passed = true
+	var testRan bool
+	// Range over archMap to create session templates with different architectures
+	for arch := range archMap {
+		imageId, err := GetLatestImageIdFromCsmProductCatalog(arch)
+		if err != nil {
+			common.Infof("Unable to get latest image id for architecture %s", archMap[arch])
+			common.Warnf("Skipping BOS session template CLI tests for architecture %s", archMap[arch])
+			continue
+		}
+		testRan = true
+		for cliVersion := range bosCliVersions {
+			common.PrintLog(fmt.Sprintf("Running BOS session template CLI tests with version %s", cliVersion))
+			sessionTemplateRecord, ok := TestCLISessionTemplatesCreate(arch, imageId, bosCliVersions[cliVersion])
+			if !ok {
+				common.Errorf("Session template creation failed for imageId %s and arch %s", imageId, archMap[arch])
+				common.Warnf("Skipping rest of the BOS session template CLI tests for imageId %s and architecture %s", imageId, archMap[arch])
+				passed = false
+				continue
+			}
+			common.Infof("Session template created successfully with name %s", sessionTemplateRecord.Name)
+
+			passed = TestCLISessionTemplatesUpdate(sessionTemplateRecord.Name, imageId, bosCliVersions[cliVersion]) &&
+				TestCLISessionTemplatesDelete(sessionTemplateRecord.Name, bosCliVersions[cliVersion]) &&
+				TestCLISessionTemplatesGetAll(sessionTemplateRecord.Name, bosCliVersions[cliVersion])
+		}
+
+	}
+	if !testRan {
+		common.Infof("No image found for supported architecture")
+		common.Warnf("Skipping BOS session template CLI tests")
+		// No image found for supported architecture, skip the tests
+		// return true to indicate that the tests were skipped successfully
+		return true
+	}
+	return passed
+}
+
+func TestCLISessionTemplatesCreate(arch, imageId, cliVersion string) (sessionTemplateRecord BOSSessionTemplate, passed bool) {
+	// Create a session template using the CLI
+	templateName := "BOS_SessionTemplate_" + string(common.GetRandomString(10))
+	common.PrintLog(fmt.Sprintf("Creating BOS session template %s with image ID %s and  arch %s", templateName, imageId, arch))
+
+	cfgName := "CFS_Configuration_" + string(common.GetRandomString(10))
+	// create sessiontemplates payload
+	fileName, payload, success := GetCreateBOSSessionTemplatePayloadCLI(cfgName, false, arch, imageId)
+	if !success {
+		return BOSSessionTemplate{}, false
+	}
+
+	sessionTemplateRecord, success = CreateBOSSessionTemplatesCLI(templateName, fileName, cfgName, cliVersion)
+	if !success {
+		return BOSSessionTemplate{}, false
+	}
+
+	// Remove the created session template file
+	if err := os.Remove(fileName); err != nil {
+		common.Errorf("Unable to remove file %s: %v", fileName, err)
+	}
+
+	// Verify sessiontemplate
+	if !VerifyBOSSessionTemplate(sessionTemplateRecord, payload, templateName) {
+		common.Errorf("BOS session template %s verification failed", sessionTemplateRecord.Name)
+		return BOSSessionTemplate{}, false
+	}
+
+	// Get the created session template
+	_, success = GetBOSSessiontemplatesCLI(sessionTemplateRecord.Name, cliVersion)
+	if !success {
+		common.Errorf("Unable to get BOS session template %s", sessionTemplateRecord.Name)
+		return BOSSessionTemplate{}, false
+	}
+
+	//verify session template in list of session templates
+	sessionTemplateRecords, success := GetBOSSessiontemplatesListCLI(cliVersion)
+	if !success {
+		return BOSSessionTemplate{}, false
+	}
+
+	if !BOSSessionTemplateExists(sessionTemplateRecord.Name, sessionTemplateRecords) {
+		common.Errorf("BOS session template %s not found in list of session templates", sessionTemplateRecord.Name)
+		return BOSSessionTemplate{}, false
+	}
+
+	// Validate session template
+	if !ValidateBOSSessionTemplateCLI(sessionTemplateRecord.Name, cliVersion) {
+		return BOSSessionTemplate{}, false
+	}
+
+	return sessionTemplateRecord, true
+}
+
+func TestCLISessionTemplatesUpdate(templateName, imageId, cliVersion string) (passed bool) {
+	cfgName := "CFS_Configuration_" + string(common.GetRandomString(10))
+	// Update the session template using the CLI
+	common.PrintLog(fmt.Sprintf("Updating BOS session template %s with CFS config %s", templateName, cfgName))
+
+	// Get the existing session template
+	sessionTemplate, success := GetBOSSessiontemplatesCLI(templateName, cliVersion)
+	if !success {
+		common.Errorf("Unable to get BOS session template %s", templateName)
+		return false
+	}
+
+	// create sessiontemplates payload
+	fileName, payload, success := GetCreateBOSSessionTemplatePayloadCLI(cfgName, true, sessionTemplate.Boot_sets.Compute.Arch, imageId)
+	if !success {
+		return false
+	}
+
+	sessionTemplateRecord, success := UpdateBOSSessionTemplatesCLI(templateName, fileName, cfgName, cliVersion)
+	if !success {
+		return false
+	}
+
+	// Remove the created session template file
+	if err := os.Remove(fileName); err != nil {
+		common.Errorf("Unable to remove file %s: %v", fileName, err)
+	}
+
+	// Verify sessiontemplate
+	if !VerifyBOSSessionTemplate(sessionTemplateRecord, payload, templateName) {
+		common.Errorf("BOS session template %s verification failed", sessionTemplateRecord.Name)
+		return false
+	}
+
+	// Get the updated session template
+	_, success = GetBOSSessiontemplatesCLI(sessionTemplateRecord.Name, cliVersion)
+	if !success {
+		common.Errorf("Unable to get BOS session template %s", sessionTemplateRecord.Name)
+		return false
+	}
+
+	//verify session template in list of session templates
+	sessionTemplateRecords, success := GetBOSSessiontemplatesListCLI(cliVersion)
+	if !success {
+		return false
+	}
+
+	if !BOSSessionTemplateExists(sessionTemplateRecord.Name, sessionTemplateRecords) {
+		common.Errorf("BOS session template %s not found in list of session templates", sessionTemplateRecord.Name)
+		return false
+	}
+
+	// Validate session template
+	if !ValidateBOSSessionTemplateCLI(sessionTemplateRecord.Name, cliVersion) {
+		return false
+	}
+
+	common.Infof("BOS Session template %s updated successfully", sessionTemplateRecord.Name)
+
+	return true
+}
+
+func TestCLISessionTemplatesDelete(templateName, cliVersion string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Deleting BOS session template %s", templateName))
+
+	// Delete the session template using the CLI
+	if !DeleteBOSSessionTemplatesCLI(templateName, cliVersion) {
+		common.Errorf("Unable to delete BOS session template %s", templateName)
+		return false
+	}
+
+	// Set CLI execution return code to 2. Since the session template is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
+
+	// Get the deleted session template
+	_, success := GetBOSSessiontemplatesCLI(templateName, cliVersion)
+	if success {
+		common.Errorf("BOS session template %s was not deleted", templateName)
+		return false
+	}
+
+	// Set CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
+
+	// Verify that the session template is deleted
+	sessionTemplateRecords, success := GetBOSSessiontemplatesListCLI(cliVersion)
+	if !success {
+		return false
+	}
+
+	if BOSSessionTemplateExists(templateName, sessionTemplateRecords) {
+		common.Errorf("BOS session template %s not deleted, found in list of session templates", templateName)
+		return false
+	}
+
+	common.Infof("BOS Session template %s deleted successfully", templateName)
+
+	return true
+}
+
+func TestCLISessionTemplatesGetAll(templateName, cliVersion string) (passed bool) {
+	common.PrintLog("Getting all BOS session templates")
+
+	// Get all session templates using the CLI
+	sessionTemplateRecords, success := GetBOSSessiontemplatesListCLI(cliVersion)
+	if !success {
+		common.Errorf("Unable to get all session templates")
+		return false
+	}
+
+	common.Infof("Found %d BOS session templates", len(sessionTemplateRecords))
+
+	return true
+}

--- a/cmsdev/internal/test/ims/verify_ims_images_cli.go
+++ b/cmsdev/internal/test/ims/verify_ims_images_cli.go
@@ -29,6 +29,7 @@ package ims
  */
 import (
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
 )
 
 func TestImageCRUDOperationUsingCLI() (passed bool) {
@@ -137,11 +138,16 @@ func TestCLIImageDelete(imageId string) (passed bool) {
 		return false
 	}
 
+	// Set the CLI execution return code to 2. Since the image is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
 	// Verify the image is not in the list of images
 	if _, success := getIMSImageRecordCLI(imageId); success {
 		common.Errorf("Image %s was not soft deleted", imageId)
 		return false
 	}
+
+	// Set the CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
 
 	// Verify the image is not in the list of images
 	imageRecords, success := getIMSImageRecordsCLI()
@@ -193,16 +199,24 @@ func TestCLIImagePermanentDelete(imageId string) (passed bool) {
 	if success := PermanentDeleteIMSImageRecordCLI(imageId); !success {
 		return false
 	}
+
+	// Set the CLI execution return code to 2. Since the image is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
+
 	// Verify the image is hard deleted
 	if _, success := GetDeletedIMSImageRecordCLI(imageId); success {
 		common.Errorf("Image %s was not  permanently deleted", imageId)
 		return false
 	}
+
 	// Verify the image is not in the list of images
 	if _, success := getIMSImageRecordCLI(imageId); success {
 		common.Errorf("Image %s was not permanently deleted", imageId)
 		return false
 	}
+
+	// Set the CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
 
 	// Verify the image is not in the list of images
 	imageRecords, success := getIMSImageRecordsCLI()

--- a/cmsdev/internal/test/ims/verify_ims_public_key_cli.go
+++ b/cmsdev/internal/test/ims/verify_ims_public_key_cli.go
@@ -21,7 +21,10 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 package ims
 
-import "stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+import (
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
 
 /*
  * ims_public_key_cli_test.go
@@ -89,10 +92,15 @@ func TestCLIPublicKeyDelete(publicKeyId string) (passed bool) {
 		return false
 	}
 
+	// Set the CLI execution return code to 2. Since the public key is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
 	// verify the public key is not in the list of public keys
 	if _, success := getIMSPublicKeyRecordCLI(publicKeyId); success {
 		return false
 	}
+
+	// Set the CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
 
 	// verify the public key is not in the list of all public keys
 	publickeyRecords, success := getIMSPublicKeyRecordsCLI()
@@ -142,15 +150,23 @@ func TestCLIPublicKeyPermanentDelete(publicKeyId string) (passed bool) {
 	if success := PermanentDeleteIMSPublicKeyRecordCLI(publicKeyId); !success {
 		return false
 	}
+
+	// Set the CLI execution return code to 2. Since the public key is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
+
 	// Verify the public key is hard deleted
 	if _, success := GetDeletedIMSPublicKeyRecordCLI(publicKeyId); success {
 		return false
 	}
+
 	// Verify the public key is not in the list of public keys
 	if _, success := getIMSPublicKeyRecordCLI(publicKeyId); success {
 		common.Errorf("Public key %s was not permanently deleted", publicKeyId)
 		return false
 	}
+
+	// Set the CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
 
 	// verify the public key is not in the list of all public keys
 	publickeyRecords, success := getIMSPublicKeyRecordsCLI()

--- a/cmsdev/internal/test/ims/verify_ims_recipes_cli.go
+++ b/cmsdev/internal/test/ims/verify_ims_recipes_cli.go
@@ -23,6 +23,7 @@ package ims
 
 import (
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
 )
 
 /*
@@ -142,11 +143,17 @@ func TestCLIRecipeDelete(recipeId string) (passed bool) {
 		return false
 	}
 
+	// Set the CLI execution return code to 2. Since the recipe is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
+
 	// Verify the recipe is not in the list of recipes
 	if _, success := getIMSRecipeRecordCLI(recipeId); success {
 		common.Errorf("Recipe %s was not soft deleted", recipeId)
 		return false
 	}
+
+	// Set the CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
 
 	// Verify the recipe is not in the list of all recipes
 	recipeRecords, success := getIMSRecipeRecordsCLI()
@@ -196,16 +203,24 @@ func TestCLIRecipePermanentDelete(recipeId string) (passed bool) {
 	if success := PermanentDeleteIMSRecipeRecordCLI(recipeId); !success {
 		return false
 	}
+
+	// Set the CLI execution return code to 2. Since the recipe is deleted, the command should return 2.
+	test.SetCliExecreturnCode(2)
+
 	// Verify the recipe is hard deleted
 	if _, success := GetDeletedIMSRecipeRecordCLI(recipeId); success {
 		common.Errorf("Recipe %s was not permanently deleted", recipeId)
 		return false
 	}
+
 	// Verify the recipe is not in the list of recipes
 	if _, success := getIMSRecipeRecordCLI(recipeId); success {
 		common.Errorf("Recipe %s was not permanently deleted", recipeId)
 		return false
 	}
+
+	// Set the CLI execution return code to 0.
+	test.SetCliExecreturnCode(0)
 
 	// Verify the recipe is not in the list of all recipes
 	recipeRecords, success := getIMSRecipeRecordsCLI()


### PR DESCRIPTION
## Summary and Scope
[CASMCMS-9409](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9409): IMS cli test should suppress expected failures from log
CASMCMS-9348: BOS sessiontemplates and sessions CLI tests
Tests added in cmsdev testsuite for BOS sessiontemplates and sessions.

- Sessiontemplates: It requires cfs configurations name, It also requires `boot_sets` related information which is dependent on 
images. The test is intended for BOS so using a dummy cfs configuration name since there is no validation for cfs configuration name if it exists or not.

* Test is run for `default` and version `v2`
* Test is designed to created session temapate for x86 and ARM architectures.
* Test suite includes create, update, delete, get by session tempate name and get all session templates.
* Other CRUD tests are skipped if create session template failes.
* Test suite is skipped if x86 and ARM images are not present in product catalog. test is marked as passed
   and a warning is logged.
* Following validations are performed after session template creation.
   + Verify the data of session template with data supplied in the creation payload.
   + Get session template by name.
   + Get all session templates and verify the newly created session template is in the list.
   + Validate the created session template with `sessiontemplatevalid` option.

- Sessions: The test needs session template as key parameter and is validated during creating session if session template exists or not. 

* Test is run for `default` and version `v2`
* Test is designed to use session template for  x86 and ARM architectures.
* Test is designed to create staged and non staged sesisons.
* Other CRUD tests are skipped if create session failes.
* Test suite is skipped if x86 and ARM images are not present in product catalog. test is marked as passed
   and a warning is logged.
* Sesison is created with `limit` option and a dummy `xname` is specified to restrict the test to be non destructive.
* Following validations are performed after session creation.
   + Verify the data of session with data supplied in the creation payload.
   + Get session by name.
   + Get all session and verify the newly created session is in the list.



## Testing
Testing was performed on mug and test log is attached for reference.
[cmsdev_bos_test_log_05132025.txt](https://github.com/user-attachments/files/20197186/cmsdev_bos_test_log_05132025.txt)

CASMCMS-9409: test log for reference.
[cmsdev_IMS_test_log_05132025.txt](https://github.com/user-attachments/files/20199398/cmsdev_IMS_test_log_05132025.txt)





## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

