### PR TITLE
CASMCMS-9349:CFS configurations and sources CRUD API cmsdev tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- CASMCMS-9349: cmsdev CFS Add create/modify/delete tests
+   * API tests for sources and configurations
+
 ## [1.31.0] - 2025-05-14
 
 ### Added

--- a/cmsdev/internal/lib/common/common.go
+++ b/cmsdev/internal/lib/common/common.go
@@ -334,7 +334,8 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 		Methods: map[string]*endpointMethod{
 			"GET": newMethodEndpoint("", "Retrieve CFS configurations", []int{200, 400}),
 		},
-		Url:     "/apis/cfs/v2/configurations",
+		Url:     "/apis/cfs",
+		Uri:     "/configurations",
 		Version: "v2",
 	}
 	endpoints["cfs"]["options"] = &Endpoint{
@@ -357,6 +358,18 @@ func GetEndpoints() map[string]map[string]*Endpoint {
 		},
 		Url:     "/apis/cfs/healthz",
 		Version: "v2",
+	}
+
+	endpoints["cfs"]["sources"] = &Endpoint{
+		Methods: map[string]*endpointMethod{
+			"GET":    newMethodEndpoint("", "Retrieve all CFS sources", []int{200, 400, 404}),
+			"POST":   newMethodEndpoint("", "Create a CFS source", []int{201, 400, 409}),
+			"PATCH":  newMethodEndpoint("", "Update a CFS source", []int{200, 400, 404}),
+			"DELETE": newMethodEndpoint("", "Delete a CFS source", []int{204, 400, 404}),
+		},
+		Url:     "/apis/cfs",
+		Uri:     "/sources",
+		Version: "v3",
 	}
 
 	// IMS service endpoints

--- a/cmsdev/internal/test/cfs/cfs.go
+++ b/cmsdev/internal/test/cfs/cfs.go
@@ -91,6 +91,12 @@ func IsCFSRunning() (passed bool) {
 	if !testCFSAPI() {
 		passed = false
 	}
+	if !TestCFSConfigurationsCRUDOperationUsingAPIVersions() {
+		passed = false
+	}
+	if !TestCFSSourcesCRUDOperation() {
+		passed = false
+	}
 	if !testCFSCLI() {
 		passed = false
 	}

--- a/cmsdev/internal/test/cfs/cfs_api.go
+++ b/cmsdev/internal/test/cfs/cfs_api.go
@@ -31,6 +31,7 @@ package cfs
 import (
 	"fmt"
 	"net/http"
+
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
 	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
 )
@@ -69,6 +70,21 @@ var cfsEndpoints = []cfsEndpoint{
 		IdField:  "name",
 		Versions: []int{3},
 	},
+}
+
+func GetSupportAPIVersions(component string) (versions []string) {
+	// Get the supported API versions for a given component
+	// The component name is the last part of the URL, e.g. /apis/cfs/v3/components
+	versions = []string{}
+	for _, endpoint := range cfsEndpoints {
+		if endpoint.Name == component {
+			for _, ver := range endpoint.Versions {
+				versions = append(versions, fmt.Sprintf("v%d", ver))
+			}
+			break
+		}
+	}
+	return
 }
 
 func (endpoint cfsEndpoint) InVersion(version int) bool {

--- a/cmsdev/internal/test/cfs/cfs_configurations_api.go
+++ b/cmsdev/internal/test/cfs/cfs_configurations_api.go
@@ -1,0 +1,361 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+* cfs_configurations_api.go
+*
+* cfs configurations api functions
+*
+ */
+package cfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/k8s"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
+
+func GetCsmProductCatalogData() (data map[string]interface{}, err error) {
+	resp, err := k8s.GetConfigMapDataField(common.NAMESPACE, common.CSMPRODCATALOGCMNAME, "csm")
+	if err != nil {
+		return nil, err
+	}
+
+	//convert YAML
+	respMap, err := common.DecodeYAMLIntoStringMap(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return respMap, nil
+}
+
+func GetCSMLatestVersion(prodCatlogData map[string]interface{}) (version string, err error) {
+	// Sort the keys in the JSON object to ensure consistent ordering
+	keys := make([]string, 0, len(prodCatlogData))
+	for key := range prodCatlogData {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		return "", fmt.Errorf("no keys found in the configuration map")
+	}
+	//Get the last key from the sorted keys where version has both configuration and images as keys
+	latestCSMVersion := ""
+	for i := len(keys) - 1; i >= 0; i-- {
+		key := keys[i]
+		if _, ok := prodCatlogData[key].(map[interface{}]interface{})["configuration"]; ok {
+			if _, ok := prodCatlogData[key].(map[interface{}]interface{})["images"]; ok {
+				latestCSMVersion = key
+				break
+			}
+		}
+	}
+
+	common.Infof("Latest CSM version: %s", latestCSMVersion)
+	return latestCSMVersion, nil
+}
+
+func GetProdCatalogConfigData() (cfsConfigLayerData CsmProductCatalogConfiguration, err error) {
+	pordCatalogData, err := GetCsmProductCatalogData()
+	if err != nil {
+		return CsmProductCatalogConfiguration{}, err
+	}
+
+	// Get the latest CSM version data
+	csmVersion, err := GetCSMLatestVersion(pordCatalogData)
+	if err != nil {
+		return CsmProductCatalogConfiguration{}, err
+	}
+	latestCSMDataRaw := pordCatalogData[csmVersion]
+	common.Infof("Latest CSM data: %v", latestCSMDataRaw)
+	latestCSMData := latestCSMDataRaw.(map[interface{}]interface{})
+	return CsmProductCatalogConfiguration{
+		Clone_url: latestCSMData["configuration"].(map[interface{}]interface{})["clone_url"].(string),
+		Commit:    latestCSMData["configuration"].(map[interface{}]interface{})["commit"].(string),
+	}, nil
+
+}
+
+func GetCreateCFGConfigurationPayload(apiVersion string) (payload string, ok bool) {
+	common.Infof("Getting product catalog configuration layer data")
+	configData, err := GetProdCatalogConfigData()
+	if err != nil {
+		return "", false
+	}
+
+	cfgLayerName := "Configuration_Layer_" + string(common.GetRandomString(10))
+
+	// Create the CFS configuration payload
+	cfsPayload := map[string]interface{}{
+		"layers": []map[string]string{
+			{
+				"commit":   configData.Commit,
+				"playbook": DEFAULT_PLAYBOOK,
+				"name":     cfgLayerName,
+			},
+		},
+	}
+
+	// Setting the clone_url in the payload based on the API version
+	// As per API spec For v3, use "clone_url" key, for others, use "cloneUrl" key
+	layers, ok := cfsPayload["layers"].([]map[string]string)
+	if !ok {
+		common.Error(fmt.Errorf("failed to type-assert layers as []map[string]string"))
+		return "", false
+	}
+
+	if apiVersion == "v3" {
+		layers[0]["clone_url"] = configData.Clone_url
+	} else {
+		layers[0]["cloneUrl"] = configData.Clone_url
+	}
+
+	jsonPayload, err := json.Marshal(cfsPayload)
+	if err != nil {
+		common.Error(err)
+		return "", false
+	}
+
+	common.Infof("CFS configuration payload: %s", string(jsonPayload))
+	return string(jsonPayload), true
+}
+
+func CreateUpdateCFSConfigurationRecordAPI(cfgName, apiVersion, payload string) (cfsConfig CFSConfiguration, ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return CFSConfiguration{}, false
+	}
+
+	// Set the payload for the request
+	params.JsonStr = payload
+	url := constructCFSURL("configurations", apiVersion) + "/" + cfgName
+	resp, err := test.RestfulVerifyStatus("PUT", url, *params, http.StatusOK)
+
+	if err != nil {
+		common.Error(err)
+		return CFSConfiguration{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsConfig); err != nil {
+		common.Error(err)
+		return CFSConfiguration{}, false
+	}
+
+	ok = true
+	return
+}
+
+func GetCFSConfigurationRecordAPI(cfgName, apiVersion string, httpStatus int) (cfsConfig CFSConfiguration, ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return CFSConfiguration{}, false
+	}
+
+	url := constructCFSURL("configurations", apiVersion) + "/" + cfgName
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, httpStatus)
+
+	if err != nil {
+		common.Error(err)
+		return CFSConfiguration{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsConfig); err != nil {
+		common.Error(err)
+		return CFSConfiguration{}, false
+	}
+
+	ok = true
+	return
+}
+
+func GetCFSConfigurationsListAPIV2(apiVersion string) (cfsConfigurations []CFSConfiguration, ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return []CFSConfiguration{}, false
+	}
+
+	url := constructCFSURL("configurations", apiVersion)
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+
+	if err != nil {
+		common.Error(err)
+		return []CFSConfiguration{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsConfigurations); err != nil {
+		common.Error(err)
+		return []CFSConfiguration{}, false
+	}
+
+	ok = true
+	return
+}
+
+func GetCFSConfigurationsListAPI(apiVersion string) (cfsConfigurations CFSConfigurationsList, ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return CFSConfigurationsList{}, false
+	}
+
+	url := constructCFSURL("configurations", apiVersion)
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+
+	if err != nil {
+		common.Error(err)
+		return CFSConfigurationsList{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsConfigurations); err != nil {
+		common.Error(err)
+		return CFSConfigurationsList{}, false
+	}
+
+	ok = true
+	return
+}
+
+func GetAPIBasedCFSConfigurationRecordList(apiVersion string) (cfsConfig []CFSConfiguration, ok bool) {
+	// Get the CFS configurations list based on the API version. The response will be different for v2 and v3.
+	// For v3, the response will be a list of CFSConfigurationsList, while for v2, it will be a CFSConfigurations struct.
+	if apiVersion == "v3" {
+		cfsConfigV3, ok := GetCFSConfigurationsListAPI(apiVersion)
+		if !ok {
+			return []CFSConfiguration{}, false
+		}
+		cfsConfig = cfsConfigV3.Configurations
+	} else {
+		cfsConfig, ok = GetCFSConfigurationsListAPIV2(apiVersion)
+		if !ok {
+			return []CFSConfiguration{}, false
+		}
+	}
+	return cfsConfig, true
+}
+
+func DeleteCFSConfigurationRecordAPI(cfgName, apiVersion string) (ok bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return false
+	}
+
+	url := constructCFSURL("configurations", apiVersion) + "/" + cfgName
+	_, err := test.RestfulVerifyStatus("DELETE", url, *params, http.StatusNoContent)
+
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	ok = true
+	return
+}
+
+func CFSConfigurationExists(cfsConfigurations []CFSConfiguration, cfgName string) (ok bool) {
+	for _, cfsConfig := range cfsConfigurations {
+		if cfsConfig.Name == cfgName {
+			common.Infof("CFS configuration %s was found in the list of configurations", cfgName)
+			return true
+		}
+	}
+	common.Infof("CFS configuration %s was not found in the list of configurations", cfgName)
+	return false
+}
+
+func VerifyCFSConfigurationRecord(cfsConfig CFSConfiguration, cfsPayload, cfgName, apiVersion string) (ok bool) {
+	ok = true
+	// Verify the CFS configuration record
+	var cfsConfigPayload map[string]interface{}
+	var cfsConfiglayerMap map[string]string
+
+	// Decode the cfs configuration payload into a map[string]interface{}
+	if err := json.Unmarshal([]byte(cfsPayload), &cfsConfigPayload); err != nil {
+		common.Error(err)
+		return false
+	}
+
+	cfsConfigPayloadLayerInterface := cfsConfigPayload["layers"].([]interface{})
+	cfsConfigPayloadLayerInt := cfsConfigPayloadLayerInterface[0].(map[string]interface{})
+
+	// Convert map[string]interface{} to map[string]string
+	cfsConfigPayloadLayerMap := make(map[string]string)
+	for key, value := range cfsConfigPayloadLayerInt {
+		if strValue, ok := value.(string); ok {
+			cfsConfigPayloadLayerMap[key] = strValue
+		} else {
+			common.Warnf("Skipping non-string value for key %s", key)
+		}
+	}
+
+	//Extract cfs configuration layer data from the cfs configuration record
+
+	if len(cfsConfig.Layers) > 0 {
+		// Convert the first layer of cfsConfig to a map[string]string
+		cfsConfiglayerMap = map[string]string{
+			"commit":   cfsConfig.Layers[0].Commit,
+			"playbook": cfsConfig.Layers[0].Playbook,
+			"name":     cfsConfig.Layers[0].Name,
+		}
+
+		if apiVersion == "v3" {
+			cfsConfiglayerMap["clone_url"] = cfsConfig.Layers[0].Clone_url
+		} else {
+			cfsConfiglayerMap["cloneUrl"] = cfsConfig.Layers[0].CloneURL
+		}
+	}
+
+	// Verify the cfs configuration layer data
+	passed := common.CompareMaps(cfsConfigPayloadLayerMap, cfsConfiglayerMap)
+	if !passed {
+		ok = false
+		common.Errorf("CFS configuration layer data mismatch: expected %v, got %v", cfsConfigPayloadLayerMap, cfsConfiglayerMap)
+	}
+
+	if cfsConfig.Name != cfgName {
+		common.Errorf("CFS configuration name mismatch: expected %s, got %s", cfgName, cfsConfig.Name)
+		ok = false
+	}
+
+	return
+}
+
+func constructCFSURL(endpoint, apiVersion string) string {
+	base := common.BASEURL + endpoints["cfs"][endpoint].Url
+	if apiVersion != "" {
+		return base + "/" + apiVersion + endpoints["cfs"][endpoint].Uri
+	}
+	return base + endpoints["cfs"][endpoint].Uri
+}

--- a/cmsdev/internal/test/cfs/cfs_defs.go
+++ b/cmsdev/internal/test/cfs/cfs_defs.go
@@ -1,0 +1,76 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * cfs_defs.go
+ *
+ * cfs definitions
+ *
+ */
+package cfs
+
+import "stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+
+var DEFAULT_PLAYBOOK = "compute_nodes.yml"
+
+type CfsLayer struct {
+	Clone_url string `json:"clone_url,omitempty"`
+	CloneURL  string `json:"cloneUrl,omitempty"`
+	Commit    string `json:"commit"`
+	Name      string `json:"name"`
+	Playbook  string `json:"playbook"`
+}
+
+type CFSConfiguration struct {
+	Layers []CfsLayer `json:"layers"`
+	Name   string     `json:"name"`
+}
+
+type CFSConfigurationsList struct {
+	Configurations []CFSConfiguration `json:"configurations"`
+}
+
+type CsmProductCatalogConfiguration struct {
+	Clone_url     string `json:"clone_url"`
+	Commit        string `json:"commit"`
+	Import_branch string `json:"import_branch"`
+	Import_Date   string `json:"import_date"`
+	Ssh_url       string `json:"ssh_url"`
+}
+
+type CFSSourceCredentials struct {
+	Authentication_method string `json:"authentication_method"`
+	Secret_name           string `json:"secret_name"`
+}
+
+type CFSSources struct {
+	Clone_url   string               `json:"clone_url"`
+	Name        string               `json:"name"`
+	Credentials CFSSourceCredentials `json:"credentials"`
+}
+
+type CFSSourcesList struct {
+	Sources []CFSSources `json:"sources"`
+}
+
+// CMS service endpoints
+var endpoints map[string]map[string]*common.Endpoint = common.GetEndpoints()

--- a/cmsdev/internal/test/cfs/cfs_sources_api.go
+++ b/cmsdev/internal/test/cfs/cfs_sources_api.go
@@ -1,0 +1,224 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * cfs_sources_api.go
+ *
+ * cfs sources api functions
+ *
+ */
+package cfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/test"
+)
+
+var firstCloneURL = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
+var secondCloneURL = "https://api-gw-service-nmn.local/vcs/cray/csm-product-catalog.git"
+
+func CreateCFSSourceRecordAPI(sourceName string) (cfsSourceRecord CFSSources, passed bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return CFSSources{}, false
+	}
+
+	// Create CFS source payload
+	payload := map[string]interface{}{
+		"name":      sourceName,
+		"clone_url": firstCloneURL,
+		"credentials": map[string]string{
+			"username":              "testuser",
+			"password":              "testpassword",
+			"authentication_method": "password",
+		},
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	params.JsonStr = string(jsonPayload)
+	common.Infof("CFS configuration payload: %s", string(jsonPayload))
+
+	url := common.BASEURL + endpoints["cfs"]["sources"].Url + "/" + endpoints["cfs"]["sources"].Version + endpoints["cfs"]["sources"].Uri
+	resp, err := test.RestfulVerifyStatus("POST", url, *params, http.StatusCreated)
+
+	if err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsSourceRecord); err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	passed = true
+	return
+}
+
+func UpdateCFSSourceRecordAPI(sourceName string) (cfsSourceRecord CFSSources, passed bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return CFSSources{}, false
+	}
+
+	// Create CFS source payload
+	payload := map[string]string{
+		"clone_url": secondCloneURL,
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	params.JsonStrArray = jsonPayload
+	common.Infof("CFS configuration payload: %s", string(jsonPayload))
+
+	url := common.BASEURL + endpoints["cfs"]["sources"].Url + "/" + endpoints["cfs"]["sources"].Version + endpoints["cfs"]["sources"].Uri + "/" + sourceName
+	resp, err := test.RestfulVerifyStatus("PATCH", url, *params, http.StatusOK)
+
+	if err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsSourceRecord); err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	passed = true
+	return
+}
+
+func DeleteCFSSourceRecordAPI(sourceName string) (passed bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return false
+	}
+
+	url := common.BASEURL + endpoints["cfs"]["sources"].Url + "/" + endpoints["cfs"]["sources"].Version + endpoints["cfs"]["sources"].Uri + "/" + sourceName
+	_, err := test.RestfulVerifyStatus("DELETE", url, *params, http.StatusNoContent)
+
+	if err != nil {
+		common.Error(err)
+		return false
+	}
+
+	return true
+}
+
+func GetCFSSourceRecordAPI(sourceName string, httpStatus int) (cfsSourceRecord CFSSources, passed bool) {
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return CFSSources{}, false
+	}
+
+	url := common.BASEURL + endpoints["cfs"]["sources"].Url + "/" + endpoints["cfs"]["sources"].Version + endpoints["cfs"]["sources"].Uri + "/" + sourceName
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, httpStatus)
+
+	if err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsSourceRecord); err != nil {
+		common.Error(err)
+		return CFSSources{}, false
+	}
+
+	passed = true
+	return
+}
+
+func GetCFSSourcesListAPI() (cfsSources []CFSSources, passed bool) {
+	var cfsSourcesList CFSSourcesList
+	params := test.GetAccessTokenParams()
+	if params == nil {
+		common.Error(fmt.Errorf("Unable to get access token params"))
+		return []CFSSources{}, false
+	}
+
+	url := common.BASEURL + endpoints["cfs"]["sources"].Url + "/" + endpoints["cfs"]["sources"].Version + endpoints["cfs"]["sources"].Uri
+	resp, err := test.RestfulVerifyStatus("GET", url, *params, http.StatusOK)
+
+	if err != nil {
+		common.Error(err)
+		return []CFSSources{}, false
+	}
+
+	// Decoding the response body into the CFSConfiguration struct
+	if err := json.Unmarshal(resp.Body(), &cfsSourcesList); err != nil {
+		common.Error(err)
+		return []CFSSources{}, false
+	}
+
+	cfsSources = cfsSourcesList.Sources
+	passed = true
+	return
+}
+
+func CFSSourceExists(cfsSourcesList []CFSSources, sourceName string) (passed bool) {
+	passed = false
+	for _, source := range cfsSourcesList {
+		if source.Name == sourceName {
+			common.Infof("CFS source %s found in the list", sourceName)
+			return true
+		}
+	}
+	common.Infof("CFS source %s not found in the list", sourceName)
+	return false
+}
+
+func VerifyCFSSourceRecord(cfsSourceRecord CFSSources, sourceName, cloneUrl string) (passed bool) {
+	passed = true
+	if cfsSourceRecord.Name != sourceName {
+		common.Errorf("CFS source name mismatch: expected %s, found %s", sourceName, cfsSourceRecord.Name)
+		passed = false
+	}
+	if cfsSourceRecord.Clone_url != cloneUrl {
+		common.Errorf("CFS source clone_url mismatch: expected %s, found %s", cloneUrl, cfsSourceRecord.Clone_url)
+		passed = false
+	}
+	if cfsSourceRecord.Credentials.Authentication_method != "password" {
+		common.Errorf("CFS source authentication method mismatch: expected password, found %s", cfsSourceRecord.Credentials.Authentication_method)
+		passed = false
+	}
+	return passed
+}

--- a/cmsdev/internal/test/cfs/verify_cfs_configurations.go
+++ b/cmsdev/internal/test/cfs/verify_cfs_configurations.go
@@ -1,0 +1,186 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * verify_cfs_configurations.go
+ *
+ * cfs configurations test api functions
+ *
+ */
+package cfs
+
+import (
+	"fmt"
+	"net/http"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+func TestCFSConfigurationsCRUDOperationUsingAPIVersions() (passed bool) {
+	passed = true
+	// Get supported API versions for configurations endpoints
+	for _, apiVersion := range GetSupportAPIVersions("configurations") {
+		common.PrintLog(fmt.Sprintf("Testing CFS configurations CRUD operations using API version: %s", apiVersion))
+		passed = passed && TestCFSConfigurationsCRUDOperation(apiVersion)
+	}
+
+	return passed
+}
+
+func TestCFSConfigurationsCRUDOperation(apiVersion string) (passed bool) {
+	cfsConfigurationRecord, success := TestCFSConfigurationCreate(apiVersion)
+	if !success {
+		return false
+	}
+
+	updated := TestCFSConfigurationUpdate(cfsConfigurationRecord.Name, apiVersion)
+
+	deleted := TestCFSConfigurationDelete(cfsConfigurationRecord.Name, apiVersion)
+
+	getAll := TestCFSConfigurationGetAll(apiVersion)
+
+	return updated && deleted && getAll
+}
+
+func TestCFSConfigurationCreate(apiVersion string) (cfsConfigurationRecord CFSConfiguration, success bool) {
+	cfgName := "CFS_Configuration_" + string(common.GetRandomString(10))
+
+	common.PrintLog(fmt.Sprintf("Creating CFS configuration: %s", cfgName))
+
+	// get CFS configuration payload
+	cfsConfigurationPayload, success := GetCreateCFGConfigurationPayload(apiVersion)
+	if !success {
+		return CFSConfiguration{}, false
+	}
+
+	// create CFS configuration
+	cfsConfigurationRecord, success = CreateUpdateCFSConfigurationRecordAPI(cfgName, apiVersion, cfsConfigurationPayload)
+	if !success {
+		return CFSConfiguration{}, false
+	}
+
+	// verify Cfs configuration record
+	_, success = GetCFSConfigurationRecordAPI(cfgName, apiVersion, http.StatusOK)
+	if !success {
+		common.Errorf("Unable to get CFS configuration record: %s", cfgName)
+		return CFSConfiguration{}, false
+	}
+
+	// Verify cfs configurations in the list of configurations
+	cfsConfigurations, success := GetAPIBasedCFSConfigurationRecordList(apiVersion)
+	if !success {
+		common.Errorf("Unable to get CFS configurations list")
+		return CFSConfiguration{}, false
+	}
+
+	if !CFSConfigurationExists(cfsConfigurations, cfgName) {
+		common.Errorf("CFS configuration %s was not found in the list of cfs configurations", cfgName)
+		return CFSConfiguration{}, false
+	}
+
+	// Verify the CFS configuration record
+	if !VerifyCFSConfigurationRecord(cfsConfigurationRecord, cfsConfigurationPayload, cfgName, apiVersion) {
+		return CFSConfiguration{}, false
+	}
+	common.Infof("CFS configuration record created successfully: %s", cfsConfigurationRecord.Name)
+
+	return cfsConfigurationRecord, true
+}
+
+func TestCFSConfigurationUpdate(cfgName, apiVersion string) (success bool) {
+	common.PrintLog(fmt.Sprintf("Updating CFS configuration: %s", cfgName))
+	// get CFS configuration payload
+	cfsConfigurationPayload, success := GetCreateCFGConfigurationPayload(apiVersion)
+	if !success {
+		return false
+	}
+
+	// Update CFS configuration record
+	cfsConfigurationRecord, success := CreateUpdateCFSConfigurationRecordAPI(cfgName, apiVersion, cfsConfigurationPayload)
+	if !success {
+		return false
+	}
+
+	// Verify the CFS configuration record
+	_, success = GetCFSConfigurationRecordAPI(cfgName, apiVersion, http.StatusOK)
+	if !success {
+		return false
+	}
+
+	// Verify cfs configurations in the list of configurations
+	cfsConfigurations, success := GetAPIBasedCFSConfigurationRecordList(apiVersion)
+	if !success {
+		return false
+	}
+
+	if !CFSConfigurationExists(cfsConfigurations, cfgName) {
+		return false
+	}
+
+	if !VerifyCFSConfigurationRecord(cfsConfigurationRecord, cfsConfigurationPayload, cfgName, apiVersion) {
+		return false
+	}
+	common.Infof("CFS configuration record updated successfully: %s", cfsConfigurationRecord.Name)
+
+	return true
+}
+
+func TestCFSConfigurationDelete(cfgName string, apiVersion string) (success bool) {
+	common.PrintLog(fmt.Sprintf("Deleting CFS configuration: %s", cfgName))
+	// Delete CFS configuration record
+	success = DeleteCFSConfigurationRecordAPI(cfgName, apiVersion)
+	if !success {
+		return false
+	}
+
+	// Verify CFS configuration record is deleted
+	_, success = GetCFSConfigurationRecordAPI(cfgName, apiVersion, http.StatusNotFound)
+	if !success {
+		return false
+	}
+
+	// Verify cfs configurations is not in the list of configurations
+	cfsConfigurations, success := GetAPIBasedCFSConfigurationRecordList(apiVersion)
+	if !success {
+		return false
+	}
+
+	if CFSConfigurationExists(cfsConfigurations, cfgName) {
+		return false
+	}
+	common.Infof("CFS configuration %s deleted successfully", cfgName)
+
+	return true
+}
+
+func TestCFSConfigurationGetAll(apiVersion string) (success bool) {
+	common.PrintLog("Getting all CFS configurations")
+	// Get CFS configurations list
+	cfsConfigurations, success := GetAPIBasedCFSConfigurationRecordList(apiVersion)
+	if !success {
+		return false
+	}
+
+	common.Infof("Found %d CFS configurations", len(cfsConfigurations))
+
+	return true
+}

--- a/cmsdev/internal/test/cfs/verify_cfs_sources.go
+++ b/cmsdev/internal/test/cfs/verify_cfs_sources.go
@@ -1,0 +1,176 @@
+// MIT License
+//
+// (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ * verify_cfs_sources.go
+ *
+ * cfs sources test api functions
+ *
+ */
+package cfs
+
+import (
+	"fmt"
+	"net/http"
+
+	"stash.us.cray.com/SCMS/cms-tools/cmsdev/internal/lib/common"
+)
+
+func TestCFSSourcesCRUDOperation() (passed bool) {
+	passed = true
+
+	cfsSourceRecord, success := TestCFSSourceCreate()
+	if !success {
+		return false
+	}
+
+	updated := TestCFSSourceUpdate(cfsSourceRecord.Name)
+
+	deleted := TestCFSSourceDelete(cfsSourceRecord.Name)
+
+	getAll := TestCFSSourceGetAll()
+
+	passed = passed && updated && deleted && getAll
+
+	return passed
+}
+
+func TestCFSSourceCreate() (cfsSourceRecord CFSSources, passed bool) {
+	sourceName := "CFS_Source_" + string(common.GetRandomString(10))
+	common.PrintLog(fmt.Sprintf("Creating CFS source: %s", sourceName))
+
+	// Create a new CFS source record
+	cfsSourceRecord, success := CreateCFSSourceRecordAPI(sourceName)
+	if !success {
+		return CFSSources{}, false
+	}
+
+	// Get the CFS source record
+	_, success = GetCFSSourceRecordAPI(sourceName, http.StatusOK)
+	if !success {
+		common.Errorf("Failed to get CFS source record: %s", sourceName)
+		return CFSSources{}, false
+	}
+
+	// verify CFS source is in the list of sources
+	cfsSourceList, success := GetCFSSourcesListAPI()
+	if !success {
+		common.Errorf("Failed to get CFS sources list")
+		return CFSSources{}, false
+	}
+
+	// Check if the source is in the list
+	if !CFSSourceExists(cfsSourceList, sourceName) {
+		return CFSSources{}, false
+	}
+
+	// verify the source record
+	if !VerifyCFSSourceRecord(cfsSourceRecord, sourceName, firstCloneURL) {
+		return CFSSources{}, false
+	}
+
+	common.Infof("CFS source %s created successfully", sourceName)
+	return cfsSourceRecord, true
+}
+
+func TestCFSSourceUpdate(sourceName string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Updating CFS source: %s", sourceName))
+
+	// Update the CFS source record
+	cfsSourceRecord, success := UpdateCFSSourceRecordAPI(sourceName)
+	if !success {
+		return false
+	}
+
+	// Get the CFS source record
+	_, success = GetCFSSourceRecordAPI(sourceName, http.StatusOK)
+	if !success {
+		common.Errorf("Failed to get CFS source record: %s", sourceName)
+		return false
+	}
+
+	// verify CFS source is in the list of sources
+	cfsSourceList, success := GetCFSSourcesListAPI()
+	if !success {
+		common.Errorf("Failed to get CFS sources list")
+		return false
+	}
+
+	// Check if the source is in the list
+	if !CFSSourceExists(cfsSourceList, sourceName) {
+		return false
+	}
+
+	// Verify the CFS source record
+	if !VerifyCFSSourceRecord(cfsSourceRecord, sourceName, secondCloneURL) {
+		return false
+	}
+
+	common.Infof("CFS source %s updated successfully", sourceName)
+	return true
+}
+
+func TestCFSSourceDelete(sourceName string) (passed bool) {
+	common.PrintLog(fmt.Sprintf("Deleting CFS source: %s", sourceName))
+
+	// Delete the CFS source record
+	success := DeleteCFSSourceRecordAPI(sourceName)
+	if !success {
+		return false
+	}
+
+	// Verify the CFS source record is deleted
+	_, success = GetCFSSourceRecordAPI(sourceName, http.StatusNotFound)
+	if !success {
+		return false
+	}
+
+	// verify CFS source is not in the list of sources
+	cfsSourceList, success := GetCFSSourcesListAPI()
+	if !success {
+		return false
+	}
+
+	// Check if the source is in the list
+	if CFSSourceExists(cfsSourceList, sourceName) {
+		return false
+	}
+
+	common.Infof("CFS source %s deleted successfully", sourceName)
+	return true
+}
+
+func TestCFSSourceGetAll() (passed bool) {
+	common.PrintLog("Getting all CFS sources")
+	// Get CFS sources list
+	cfsSources, success := GetCFSSourcesListAPI()
+	if !success {
+		return false
+	}
+
+	for _, source := range cfsSources {
+		common.Infof("CFS source: %s", source.Name)
+	}
+
+	common.Infof("Found %d CFS sources", len(cfsSources))
+	return true
+}


### PR DESCRIPTION
CASMCMS-9349:CFS configurations and sources CRUD API cmsdev tests

Tests added in cmsdev testsuite for CFS configurations and sources.

`configurations`
- Tests for both V2 and V3
- Following validations are performed after configurations creation.
    - Verify the data of configurations with data supplied in the creation payload.
    - Get configurations by name.
    - Get all configuration and verify the newly created configuration is in the list.
   
`sources`
- Tests for supported API version V3
- Following validations are performed after source creation.
    - Verify the data of sources with data supplied in the creation payload.
    - Get sources by name.
    - Get all sources and verify the newly created source is in the list.


Testing was performed on mug and test log is attached for reference.
[cmsdev_cfs_test_log_05162025.txt](https://github.com/user-attachments/files/20259353/cmsdev_cfs_test_log_05162025.txt)



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

