### PR TITLE
CASMCMS-9534: cmsdev: Create BOS session templates with accurate kernel parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - CASMCMS-8550: cmsdev: Add timeouts for CLI and API calls
 
+### Fixed
+- CASMCMS-9534: cmsdev: Corrected non-impactful but incorrect `kernel_parameters` value
+  for session template being created.
+
 ### Dependencies
 - Bump `github.com/go-openapi/jsonpointer` from 0.21.1 to 0.21.2 ([#296](https://github.com/Cray-HPE/cms-tools/pull/296))
 - Bump `github.com/spf13/pflag` from 1.0.6 to 1.0.7 ([#295](https://github.com/Cray-HPE/cms-tools/pull/295))

--- a/cmsdev/internal/test/bos/bos_sessiontemplates_api.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplates_api.go
@@ -171,8 +171,8 @@ func GetCreateBOSSessionTemplatePayload(cfsConfigName string, enableCFS bool, ar
 			"modprobe.blacklist=amdgpu numa_interleave_omit=headless oops=panic pageblock_order=14 " +
 			"rd.neednet=1 rd.retry=10 rd.shell split_lock_detect=off " +
 			"systemd.unified_cgroup_hierarchy=1 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} " +
-			fmt.Sprintf("root=live:s3://boot-images/%s/rootfs ", imageRecord.Name) +
-			fmt.Sprintf("nmd_data=url=s3://boot-images/%s/rootfs,etag=%s", imageRecord.Name, imageRecord.Link.S3_Etag)
+			fmt.Sprintf("root=live:s3://boot-images/%s/rootfs ", imageRecord.ImageID) +
+			fmt.Sprintf("nmd_data=url=s3://boot-images/%s/rootfs,etag=%s", imageRecord.ImageID, imageRecord.Link.S3_Etag)
 
 	computeSet := map[string]interface{}{
 		"etag":              imageRecord.Link.S3_Etag,


### PR DESCRIPTION
## Summary and Scope

The `cmsdev` test currently creates BOS session templates with subtly incorrect kernel parameters strings in their boot sets. I noticed this on `fanta`:

```toml
kernel_parameters = "console=ttyS0,115200 bad_page=panic crashkernel=512M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu.passthrough=on modprobe.blacklist=amdgpu numa_interleave_omit=headless oops=panic pageblock_order=14 rd.neednet=1 rd.retry=10 rd.shell split_lock_detect=off systemd.unified_cgroup_hierarchy=1 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} root=live:s3://boot-images/compute-csm-1.7-7.1.37-x86_64/rootfs nmd_data=url=s3://boot-images/compute-csm-1.7-7.1.37-x86_64/rootfs,etag=dc3790a50f95fa96c295829eb6aa7d0d"
```

In the two S3 paths, it is using the IMS image *name* where it should be using the *ID*. This PR corrects that.

## Issues and Related PRs

* Resolves [CASMCMS-9534](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9534)

## Testing

fanta, after the fix was made, here is the resulting kernel parameter string it created:

```toml
kernel_parameters = "console=ttyS0,115200 bad_page=panic crashkernel=512M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable iommu.passthrough=on modprobe.blacklist=amdgpu numa_interleave_omit=headless oops=panic pageblock_order=14 rd.neednet=1 rd.retry=10 rd.shell split_lock_detect=off systemd.unified_cgroup_hierarchy=1 ip=dhcp quiet spire_join_token=${SPIRE_JOIN_TOKEN} root=live:s3://boot-images/1150bbb7-e837-45b0-acb4-6312e4fd0d22/rootfs nmd_data=url=s3://boot-images/1150bbb7-e837-45b0-acb4-6312e4fd0d22/rootfs,etag=62002f4b397e497495323af65c25f74b"
```


## Risks and Mitigations

Very low risk -- the contents of the kernel parameter string don't really matter for the testing we are doing, but it is worth fixing.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

