### PR TITLE
CASMCMS-9537: cmsdev: Remove misleading error message from BOS test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - CASMCMS-9534: cmsdev: Corrected non-impactful but incorrect `kernel_parameters` value
   for session template being created.
+- CASMCMS-9537: cmsdev: Remove misleading error message in BOS test
 
 ### Dependencies
 - Bump `github.com/go-openapi/jsonpointer` from 0.21.1 to 0.21.2 ([#296](https://github.com/Cray-HPE/cms-tools/pull/296))

--- a/cmsdev/internal/test/bos/bos_sessiontemplates_api.go
+++ b/cmsdev/internal/test/bos/bos_sessiontemplates_api.go
@@ -432,7 +432,7 @@ func GetTenantFromList() string {
 	// Set the tenant name to be used in the tests
 	tenantName, err := common.GetRandomStringFromList(tenantList)
 	if err != nil {
-		common.Errorf("Error getting random tenant from list: %s", err.Error())
+		common.Debugf("Unable to get random tenant from list: %s", err.Error())
 		return ""
 	}
 	common.Infof("Using tenant: %s", tenantName)


### PR DESCRIPTION
## Summary and Scope

This changes a misleading error message in the BOS test into a debug message.
I cherry-picked the fix for this from @kumarrahul04 's PR for CASMCMS-9540, since this fix is not related to it.
His change made this into a warning, but upon reflection, I don't think we would want a customer to run the test and see this warning message either (since it is not an unexpected thing to happen and does not indicate a problem). So I changed it to be a debug statement instead. And I reworded it to remove the word "error" from the text, just to make sure nobody panics if they saw that in the log file.

## Issues and Related PRs

* Resolves [CASMCMS-9537](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9537)
* Caused by [CASMCMS-9472](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9472)

## Testing

Ran the old test on fanta, verified that it showed the errors, then ran the updated test, and verified that it did not show the errors, but that the new debug messages were in the log file.

## Risks and Mitigations

Low risk -- just changing an error message to a warning message.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

