### PR TITLE
CASMCMS-9636: cfs_sessions_rc_test: Fix bug causing multi-delete validation to always fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.2] - 2026-03-12
+
+### Fixed
+
+- CASMCMS-9636: cfs_sessions_rc_test: Fix bug causing multi-delete validation to always fail
+
 ## [1.34.1] - 2025-12-02
 
 ### Fixed

--- a/python-venv/cmstools/lib/cfs/__init__.py
+++ b/python-venv/cmstools/lib/cfs/__init__.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,8 +26,22 @@
 CFS module for cmstools tests
 """
 
-from .defs import (CFS_SESSIONS_URL_TEMPLATE, CFS_OPERATOR_DEPLOYMENT, CFS_OPTIONS_URL,
-                   CFS_DEFAULT_PAGE_SIZE, CFS_CONFIGS_URL)
-from .types import (SessionDeleteResult, MultiSessionsGetResult, CFS_V2_SESSIONS_DELETE_CODES,
-                    CFS_V3_SESSIONS_DELETE_CODES, SessionsGetResponse)
+from .defs import (
+                    CFS_CONFIGS_URL,
+                    CFS_DEFAULT_PAGE_SIZE,
+                    CFS_SESSIONS_URL_TEMPLATE,
+                    CFS_OPERATOR_DEPLOYMENT,
+                    CFS_OPTIONS_URL,
+                    CFS_V2_SESSIONS_DELETE_CODES,
+                    CFS_V3_SESSIONS_DELETE_CODES,
+                    CFS_VERSIONS_INT
+                  )
+from .types import (
+                    CfsV2SessionsDeleteCode,
+                    CfsV3SessionsDeleteCode,
+                    CfsVersionInt,
+                    MultiSessionsGetResult,
+                    SessionDeleteResult,
+                    SessionsGetResponse
+                   )
 from .config import create_cfs_config

--- a/python-venv/cmstools/lib/cfs/defs.py
+++ b/python-venv/cmstools/lib/cfs/defs.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,8 +26,11 @@
 CFS URL definitions
 """
 
+from typing import get_args
+
 from cmstools.lib.api import API_BASE_URL
 
+from .types import CfsV2SessionsDeleteCode, CfsV3SessionsDeleteCode, CfsVersionInt
 
 # CFS v3 URLs
 CFS_URL = f"{API_BASE_URL}/cfs/v3"
@@ -45,3 +48,12 @@ CFS_OPERATOR_DEPLOYMENT = "cray-cfs-operator"
 
 # CFS options
 CFS_DEFAULT_PAGE_SIZE = 1000
+
+# CFS versions
+# (using get_args allows us to avoid hard-coding the list in the types file and here)
+CFS_VERSIONS_INT: frozenset[CfsVersionInt] = frozenset(get_args(CfsVersionInt))
+
+# CFS sessions delete expected status codes
+# (using get_args allows us to avoid hard-coding the list in the types file and here)
+CFS_V2_SESSIONS_DELETE_CODES: frozenset[CfsV2SessionsDeleteCode] = frozenset(get_args(CfsV2SessionsDeleteCode))
+CFS_V3_SESSIONS_DELETE_CODES: frozenset[CfsV3SessionsDeleteCode] = frozenset(get_args(CfsV3SessionsDeleteCode))

--- a/python-venv/cmstools/lib/cfs/types.py
+++ b/python-venv/cmstools/lib/cfs/types.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,12 +29,11 @@ from dataclasses import dataclass
 from typing import Literal, Optional
 
 # There was a CFS v1, but it hasn't been in CSM since CSM 1.0
-CFS_VERSION_INT = Literal[ 2, 3 ]
+CfsVersionInt = Literal[ 2, 3 ]
 
 # CFS session operation HTTP return codes
-CFS_V2_SESSIONS_DELETE_CODES = Literal[ 204, 400]
-CFS_V3_SESSIONS_DELETE_CODES = Literal[ 200, 400]
-
+CfsV2SessionsDeleteCode = Literal[ 204, 400 ]
+CfsV3SessionsDeleteCode = Literal[ 200, 400 ]
 
 # Data classes
 @dataclass


### PR DESCRIPTION
The current multi-delete validation code defined in [`test/cfs_sessions_rc_test/helpers/response_handler.py`](https://github.com/Cray-HPE/cms-tools/blob/8f0782a25a285ad557a1b80c9df41b3cbaeb4a97/python-venv/cmstools/test/cfs_sessions_rc_test/helpers/response_handler.py#L100-L101) includes the following lines:

```python
        expected_codes = CFS_V3_SESSIONS_DELETE_CODES if self.script_args.cfs_version == "v3" else CFS_V2_SESSIONS_DELETE_CODES
        invalid_responses = [r for r in remaining_responses if r.status_code not in expected_codes]
```

This looks fine until you look up the definition of `CFS_V2_SESSIONS_DELETE_CODES` and `CFS_V3_SESSIONS_DELETE_CODES`  in [`python-venv/cmstools/lib/cfs/types.py`](https://github.com/Cray-HPE/cms-tools/blob/8f0782a25a285ad557a1b80c9df41b3cbaeb4a97/python-venv/cmstools/lib/cfs/types.py#L35-L36):

```python
CFS_V2_SESSIONS_DELETE_CODES = Literal[ 204, 400]
CFS_V3_SESSIONS_DELETE_CODES = Literal[ 200, 400]
```

Python `Literal` objects are for type hinting, and they are not implemented in a way that membership tests can be used like this. The current code always considers every response to have an unexpected status code, because no status code will pass this membership test.

When looking into how to fix this, I also noticed that in most cases in the code, the convention for static values is all-caps snake case, whereas camel-case is used for type definitions. These definitions (along with a definition of the CFS version integer values) do not follow this pattern, which may have been part of what led to this problem.

I fixed the problem by:

1. Renaming these Literal definitions with camel-case names, to match the other typing names.
2. Created new definitions (in `defs.py`) that are the actual lists (sets, actually) of the values. This can be done without hard-coding the values twice by using the `typing.get_args` function.

By doing it this way, the actual validation code does not need to change.

## Testing

I have tested this on surtur (installed with CSM 1.7.1), where I had originally discovered this bug. With the fix in place, the multi-delete status code checks work as expected.